### PR TITLE
Update web search tool parameters, system prompt, and response format

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,23 +1,21 @@
 // ── Constants ──────────────────────────────────────────────────────────
 
 const ANTHROPIC_NPM_PACKAGE = "@ai-sdk/anthropic";
-const DEFAULT_SEARCH_USES = 5;
+const DEFAULT_SEARCH_USES = 8;
 const EMPTY_LENGTH = 0;
 const MAX_RESPONSE_TOKENS = 16_000;
-const MAX_SEARCH_USES = 10;
 const MIN_QUERY_LENGTH = 2;
-const MIN_SEARCH_USES = 1;
 const MONTH_OFFSET = 1;
 const PAD_LENGTH = 2;
+const SEARCH_SYSTEM_PROMPT = "You are an assistant for performing a web search tool use";
 
 export {
   ANTHROPIC_NPM_PACKAGE,
   DEFAULT_SEARCH_USES,
   EMPTY_LENGTH,
   MAX_RESPONSE_TOKENS,
-  MAX_SEARCH_USES,
   MIN_QUERY_LENGTH,
-  MIN_SEARCH_USES,
   MONTH_OFFSET,
   PAD_LENGTH,
+  SEARCH_SYSTEM_PROMPT,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { MAX_SEARCH_USES, MIN_QUERY_LENGTH, MIN_SEARCH_USES } from "./constants.js";
 import { Plugin, tool } from "@opencode-ai/plugin";
 import { ProviderData, formatConfigError, resolveFromProviders } from "./config.js";
 import { executeSearch, formatErrorMessage } from "./providers/anthropic.js";
 import { AnthropicConfig } from "./types.js";
+import { MIN_QUERY_LENGTH } from "./constants.js";
 import { getCurrentMonthYear } from "./helpers.js";
 
 // ── Config resolution (lazy) ───────────────────────────────────────────
@@ -35,18 +35,12 @@ export default (async (input) => {
           allowed_domains: tool.schema
             .array(tool.schema.string())
             .optional()
-            .describe("Only include results from these domains"),
+            .describe("Only include search results from these domains"),
           blocked_domains: tool.schema
             .array(tool.schema.string())
             .optional()
-            .describe("Exclude results from these domains"),
-          max_uses: tool.schema
-            .number()
-            .min(MIN_SEARCH_USES)
-            .max(MAX_SEARCH_USES)
-            .optional()
-            .describe("Maximum number of searches to perform (default: 5)"),
-          query: tool.schema.string().min(MIN_QUERY_LENGTH).describe("The search query to execute"),
+            .describe("Never include search results from these domains"),
+          query: tool.schema.string().min(MIN_QUERY_LENGTH).describe("The search query to use"),
         },
         description: `- Allows OpenCode to search the web and use the results to inform responses
 - Provides up-to-date information for current events and recent data

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,6 @@ interface AnthropicConfig {
 // ── Anthropic Response Types ───────────────────────────────────────────
 
 interface WebSearchResult {
-  page_age?: string;
   title: string;
   type: "web_search_result";
   url: string;
@@ -28,19 +27,6 @@ interface ServerToolUse {
   type: "server_tool_use";
 }
 
-interface SearchUsage {
-  input_tokens: number;
-  output_tokens: number;
-  server_tool_use?: { web_search_requests?: number };
-}
-
 type ContentBlock = { text: string; type: "text" } | ServerToolUse | WebSearchToolResult;
 
-export {
-  AnthropicConfig,
-  ContentBlock,
-  SearchUsage,
-  ServerToolUse,
-  WebSearchResult,
-  WebSearchToolResult,
-};
+export { AnthropicConfig, ContentBlock, ServerToolUse, WebSearchResult, WebSearchToolResult };


### PR DESCRIPTION
## Summary

- Hardcode `max_uses` to 8 and remove it as a user-configurable parameter
- Add system prompt for the inner search API call
- Fix user message wording to match expected format
- Return structured JSON response (`{query, results}`) instead of markdown formatting
- Remove unused `SearchUsage` type and `page_age` field
- Update parameter descriptions for clarity

## Changes

### `src/constants.ts`
- `DEFAULT_SEARCH_USES`: 5 → 8
- Removed `MAX_SEARCH_USES` and `MIN_SEARCH_USES`
- Added `SEARCH_SYSTEM_PROMPT` constant

### `src/types.ts`
- Removed `SearchUsage` interface (no longer used)
- Removed `page_age` from `WebSearchResult`

### `src/providers/anthropic.ts`
- Added `system` prompt to the Anthropic API call
- Changed user message from `"Perform a web search for: "` to `"Perform a web search for the query: "`
- Hardcoded `max_uses: 8` in `buildWebSearchTool`
- Rewrote response processing to return structured JSON with `{title, url}` arrays and text strings

### `src/index.ts`
- Removed `max_uses` from the tool schema
- Updated parameter descriptions