### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-websearch",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Web search plugin for OpenCode, inspired by Claude Code's WebSearch tool",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps package version from 0.2.3 to 0.2.4 for release
- Once merged, `main` will be tagged `v0.2.4` to trigger CI publish