### PR TITLE
feat: add OpenAI as second web search provider

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -19,6 +19,7 @@
     "unicorn/prefer-ternary": "off",
     "import/no-nodejs-modules": "off",
     "import/no-named-export": "off",
+    "import/prefer-default-export": "off",
     "import/consistent-type-specifier-style": "off",
     "typescript/consistent-type-imports": "off",
     "max-statements": ["warn", { "max": 20 }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -23,7 +23,8 @@
     "import/consistent-type-specifier-style": "off",
     "typescript/consistent-type-imports": "off",
     "max-statements": ["warn", { "max": 20 }],
-    "max-params": ["warn", { "max": 5 }]
+    "max-params": ["warn", { "max": 5 }],
+    "no-continue": "off"
   },
   "ignorePatterns": ["dist", "node_modules"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
-OpenCode plugin that provides web search via Anthropic's server-side `web_search` API.
-Multi-file TypeScript project built with Bun, linted with oxlint.
+OpenCode plugin that provides web search via server-side web search APIs.
+Supports multiple providers (Anthropic, OpenAI). Multi-file TypeScript project built with Bun, linted with oxlint.
 
 ## Commands
 
@@ -23,12 +23,13 @@ There are no tests yet. When adding tests, use `bun:test` (built into Bun).
 ```
 src/
   index.ts              # plugin entry point — exports the plugin, wires tools
-  types.ts              # shared types (config, Anthropic response shapes)
+  types.ts              # shared types (config, provider resolution, search result shapes)
   constants.ts          # shared UPPER_SNAKE_CASE constants
-  helpers.ts            # generic utilities (date, env vars, URL normalization)
+  helpers.ts            # generic utilities (date formatting)
   config.ts             # config resolution (opencode.json, env fallback)
   providers/
     anthropic.ts        # Anthropic web search (client, execution, response formatting)
+    openai.ts           # OpenAI web search (client, execution, response formatting)
 dist/                   # build output (gitignored)
 .oxlintrc.json          # oxlint configuration
 tsconfig.json           # TypeScript config (strict, ESNext)
@@ -118,7 +119,7 @@ oxlint with plugins: `unicorn`, `typescript`, `import`, `oxc`.
 
 Key rules that shape the code:
 
-- `no-magic-numbers`, `max-statements` (10), `max-params` (3)
+- `no-magic-numbers`, `max-statements` (20), `max-params` (5)
 - `no-continue`, `no-ternary`, `curly`, `sort-keys`, `sort-imports`
 - `func-style` (expressions only), `init-declarations`, `id-length` (min 2)
 - `unicorn/catch-error-name`, `unicorn/text-encoding-identifier-case`
@@ -133,11 +134,12 @@ Disabled rules (with rationale):
 - `unicorn/prefer-ternary` -- conflicts with `no-ternary`
 - `import/no-nodejs-modules` -- this is a Node.js plugin; fs/os/path are required
 - `import/no-named-export` -- internal modules use named exports
+- `import/prefer-default-export` -- internal modules use named exports, not default
 - `import/consistent-type-specifier-style` -- no `import type` used
 - `typescript/consistent-type-imports` -- no `import type` used
 
 ## Dependencies
 
-- **Runtime:** `@anthropic-ai/sdk` -- Anthropic API client
+- **Runtime:** `@anthropic-ai/sdk` -- Anthropic API client, `openai` -- OpenAI API client
 - **Peer:** `@opencode-ai/plugin` -- OpenCode plugin SDK (provides `Plugin` type and `tool` helper)
 - **Dev:** `oxfmt`, `oxlint`, `typescript`, `@types/bun`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-OpenCode plugin that provides web search via server-side web search APIs.
+OpenCode plugin that provides web search via provider web search APIs.
 Supports multiple providers (Anthropic, OpenAI). Multi-file TypeScript project built with Bun, linted with oxlint.
 
 ## Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,10 +70,9 @@ package.json            # Bun-based project, ESM module
 
 ### Control flow
 
-- **No `continue` statements.** Restructure loops to use early returns from
-  extracted helper functions instead.
 - **No ternary expressions.** Use `if`/`else` blocks.
 - Always use **braces** with `if`/`else`/`for`/`while` (enforced by `curly`).
+- Prefer `continue` in loops to skip irrelevant iterations and reduce nesting.
 
 ### Strings
 
@@ -120,7 +119,7 @@ oxlint with plugins: `unicorn`, `typescript`, `import`, `oxc`.
 Key rules that shape the code:
 
 - `no-magic-numbers`, `max-statements` (20), `max-params` (5)
-- `no-continue`, `no-ternary`, `curly`, `sort-keys`, `sort-imports`
+- `no-ternary`, `curly`, `sort-keys`, `sort-imports`
 - `func-style` (expressions only), `init-declarations`, `id-length` (min 2)
 - `unicorn/catch-error-name`, `unicorn/text-encoding-identifier-case`
 - `typescript/no-unused-vars` (error)
@@ -131,6 +130,7 @@ Disabled rules (with rationale):
 - `unicorn/prefer-top-level-await` -- plugin is a function export, not a script
 - `unicorn/filename-case` -- PascalCase not enforced on filenames
 - `unicorn/prevent-abbreviations` -- short names like `ctx`, `env`, `url` are clear
+- `no-continue` -- `continue` is cleaner than empty if-branches or deep nesting in loops
 - `unicorn/prefer-ternary` -- conflicts with `no-ternary`
 - `import/no-nodejs-modules` -- this is a Node.js plugin; fs/os/path are required
 - `import/no-named-export` -- internal modules use named exports

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Web search plugin for [OpenCode](https://opencode.ai), inspired by Claude Code's
 
 ## Supported providers
 
-| Provider  | SDK package        | Search mechanism                                                                                                               |
-| --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| Anthropic | `@ai-sdk/anthropic` | [Server-side `web_search` tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool)                 |
-| OpenAI    | `@ai-sdk/openai`    | [Responses API web search](https://platform.openai.com/docs/guides/tools-web-search)                                          |
+| Provider  | SDK package         | Search mechanism                                                                                   |
+| --------- | ------------------- | -------------------------------------------------------------------------------------------------- |
+| Anthropic | `@ai-sdk/anthropic` | [`web_search` tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool) |
+| OpenAI    | `@ai-sdk/openai`    | [Responses API web search](https://platform.openai.com/docs/guides/tools-web-search)               |
 
 ## Install
 
@@ -29,12 +29,12 @@ No configuration is needed if your active chat model belongs to a supported prov
 
 The plugin chooses which model to use for each search:
 
-| Priority | Condition                                    | Behavior                                                                   |
-| -------- | -------------------------------------------- | -------------------------------------------------------------------------- |
-| 1        | A model is tagged `"always"`                 | That model is **always** used, regardless of what you're chatting with     |
+| Priority | Condition                                      | Behavior                                                                  |
+| -------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
+| 1        | A model is tagged `"always"`                   | That model is **always** used, regardless of what you're chatting with    |
 | 2        | Your active chat model is a supported provider | The active model is used directly -- no extra configuration needed        |
-| 3        | A model is tagged `"auto"`                   | That model is used as a **fallback** when the active model is unsupported |
-| 4        | None of the above                            | An error is returned                                                       |
+| 3        | A model is tagged `"auto"`                     | That model is used as a **fallback** when the active model is unsupported |
+| 4        | None of the above                              | An error is returned                                                      |
 
 ### `"auto"` mode (recommended)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opencode-websearch
 
-Web search plugin for [OpenCode](https://opencode.ai). Gives any OpenCode model access to real-time web results with source citations using server-side web search tools.
+Web search plugin for [OpenCode](https://opencode.ai), inspired by Claude Code's built-in web search. Gives any OpenCode model access to real-time web results with source citations using server-side web search tools.
 
 ## Supported providers
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opencode-websearch
 
-Web search plugin for [OpenCode](https://opencode.ai), inspired by Claude Code's built-in web search. Gives any OpenCode model access to real-time web results with source citations using server-side web search tools.
+Web search plugin for [OpenCode](https://opencode.ai), inspired by Claude Code's built-in web search. Gives any OpenCode model access to real-time web results with source citations.
 
 ## Supported providers
 
@@ -21,15 +21,13 @@ Add the plugin to your `opencode.json`:
 
 OpenCode will install it automatically at startup.
 
-## Configuration
+## Configuration (optional)
 
-The plugin scans your OpenCode providers for any that use a supported SDK package and picks up credentials however you've configured them -- via `/connect`, environment variables, or `options.apiKey` in your config.
-
-Tag a model with `"websearch": "auto"` or `"websearch": "always"` to control how web search selects its model.
+No configuration is needed if your active chat model belongs to a supported provider. To customize which model handles web searches, tag a model with `"websearch": "auto"` or `"websearch": "always"`.
 
 ### Model selection
 
-The plugin dynamically chooses which model to use for each search:
+The plugin chooses which model to use for each search:
 
 | Priority | Condition                                    | Behavior                                                                   |
 | -------- | -------------------------------------------- | -------------------------------------------------------------------------- |
@@ -60,41 +58,16 @@ Use `"auto"` when you want web search to work seamlessly regardless of your acti
 
 ### `"always"` mode
 
-Use `"always"` to hard-lock web search to a specific model. This is useful when you want a cheaper or faster model to always handle searches, no matter what you're chatting with.
+Use `"always"` to lock web search to a specific model, regardless of what you're chatting with.
 
 ```json
 {
   "provider": {
     "openai": {
       "models": {
-        "gpt-4o-mini": {
+        "gpt-5.2": {
           "options": {
             "websearch": "always"
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-### Custom providers
-
-This also works with custom providers that use a supported SDK package, such as a LiteLLM proxy:
-
-```json
-{
-  "provider": {
-    "my-proxy": {
-      "npm": "@ai-sdk/anthropic",
-      "options": {
-        "baseURL": "http://localhost:4000/v1/",
-        "apiKey": "{env:MY_API_KEY}"
-      },
-      "models": {
-        "claude-sonnet-4-5": {
-          "options": {
-            "websearch": "auto"
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # opencode-websearch
 
-Web search plugin for [OpenCode](https://opencode.ai), powered by Anthropic's server-side [`web_search` tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool). Gives any OpenCode model access to real-time web results with source citations -- the same web search capability available in Claude Code, brought to OpenCode.
+Web search plugin for [OpenCode](https://opencode.ai). Gives any OpenCode model access to real-time web results with source citations using server-side web search tools.
+
+## Supported providers
+
+| Provider  | SDK package        | Search mechanism                                                                                                               |
+| --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Anthropic | `@ai-sdk/anthropic` | [Server-side `web_search` tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool)                 |
+| OpenAI    | `@ai-sdk/openai`    | [Responses API web search](https://platform.openai.com/docs/guides/tools-web-search)                                          |
 
 ## Install
 
@@ -16,24 +23,24 @@ OpenCode will install it automatically at startup.
 
 ## Configuration
 
-The plugin scans your OpenCode providers for any that use `@ai-sdk/anthropic` and picks up credentials however you've configured them -- via `/connect`, environment variables, or `options.apiKey` in your config.
+The plugin scans your OpenCode providers for any that use a supported SDK package and picks up credentials however you've configured them -- via `/connect`, environment variables, or `options.apiKey` in your config.
 
 Tag a model with `"websearch": "auto"` or `"websearch": "always"` to control how web search selects its model.
 
 ### Model selection
 
-The plugin dynamically chooses which Anthropic model to use for each search, following this priority chain:
+The plugin dynamically chooses which model to use for each search:
 
-| Priority | Condition                           | Behavior                                                                    |
-| -------- | ----------------------------------- | --------------------------------------------------------------------------- |
-| 1        | A model is tagged `"always"`        | That model is **always** used, regardless of what you're chatting with      |
-| 2        | Your active chat model is Anthropic | The active model is used directly -- no extra configuration needed          |
-| 3        | A model is tagged `"auto"`          | That model is used as a **fallback** when the active model is non-Anthropic |
-| 4        | None of the above                   | An error is returned                                                        |
+| Priority | Condition                                    | Behavior                                                                   |
+| -------- | -------------------------------------------- | -------------------------------------------------------------------------- |
+| 1        | A model is tagged `"always"`                 | That model is **always** used, regardless of what you're chatting with     |
+| 2        | Your active chat model is a supported provider | The active model is used directly -- no extra configuration needed        |
+| 3        | A model is tagged `"auto"`                   | That model is used as a **fallback** when the active model is unsupported |
+| 4        | None of the above                            | An error is returned                                                       |
 
 ### `"auto"` mode (recommended)
 
-Use `"auto"` when you want web search to work seamlessly whether you're chatting with an Anthropic model or not. When your active model is Anthropic, it's used directly; otherwise the tagged model kicks in as a fallback.
+Use `"auto"` when you want web search to work seamlessly regardless of your active model. When your active model belongs to a supported provider, it's used directly; otherwise the tagged model kicks in as a fallback.
 
 ```json
 {
@@ -58,9 +65,9 @@ Use `"always"` to hard-lock web search to a specific model. This is useful when 
 ```json
 {
   "provider": {
-    "anthropic": {
+    "openai": {
       "models": {
-        "claude-haiku-3-5": {
+        "gpt-4o-mini": {
           "options": {
             "websearch": "always"
           }
@@ -73,12 +80,12 @@ Use `"always"` to hard-lock web search to a specific model. This is useful when 
 
 ### Custom providers
 
-This also works with custom providers that use `@ai-sdk/anthropic`, such as a LiteLLM proxy:
+This also works with custom providers that use a supported SDK package, such as a LiteLLM proxy:
 
 ```json
 {
   "provider": {
-    "my-anthropic": {
+    "my-proxy": {
       "npm": "@ai-sdk/anthropic",
       "options": {
         "baseURL": "http://localhost:4000/v1/",

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "opencode-websearch",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
+        "openai": "^6.22.0",
       },
       "devDependencies": {
         "@opencode-ai/plugin": "^1.1.65",
@@ -107,6 +108,8 @@
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "openai": ["openai@6.22.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw=="],
 
     "oxfmt": ["oxfmt@0.32.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.32.0", "@oxfmt/binding-android-arm64": "0.32.0", "@oxfmt/binding-darwin-arm64": "0.32.0", "@oxfmt/binding-darwin-x64": "0.32.0", "@oxfmt/binding-freebsd-x64": "0.32.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.32.0", "@oxfmt/binding-linux-arm-musleabihf": "0.32.0", "@oxfmt/binding-linux-arm64-gnu": "0.32.0", "@oxfmt/binding-linux-arm64-musl": "0.32.0", "@oxfmt/binding-linux-ppc64-gnu": "0.32.0", "@oxfmt/binding-linux-riscv64-gnu": "0.32.0", "@oxfmt/binding-linux-riscv64-musl": "0.32.0", "@oxfmt/binding-linux-s390x-gnu": "0.32.0", "@oxfmt/binding-linux-x64-gnu": "0.32.0", "@oxfmt/binding-linux-x64-musl": "0.32.0", "@oxfmt/binding-openharmony-arm64": "0.32.0", "@oxfmt/binding-win32-arm64-msvc": "0.32.0", "@oxfmt/binding-win32-ia32-msvc": "0.32.0", "@oxfmt/binding-win32-x64-msvc": "0.32.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-KArQhGzt/Y8M1eSAX98Y8DLtGYYDQhkR55THUPY5VNcpFQ+9nRZkL3ULXhagHMD2hIvjy8JSeEQEP5/yYJSrLA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-websearch",
   "version": "0.3.0",
-  "description": "Web search plugin for OpenCode using server-side web search APIs",
+  "description": "Web search plugin for OpenCode",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-websearch",
   "version": "0.3.0",
-  "description": "Web search plugin for OpenCode, inspired by Claude Code's WebSearch tool",
+  "description": "Web search plugin for OpenCode using server-side web search APIs",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,6 +31,7 @@
     "opencode-plugin",
     "web-search",
     "anthropic",
+    "openai",
     "ai"
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.52.0"
+    "@anthropic-ai/sdk": "^0.52.0",
+    "openai": "^6.22.0"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.1.65",

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,21 +55,27 @@ const extractApiKey = (options: Record<string, unknown>): string | undefined => 
   return options.apiKey;
 };
 
-const extractBaseURL = (options: Record<string, unknown>): string | undefined => {
+const extractBaseURL = (options: Record<string, unknown>, pt: ProviderType): string | undefined => {
   if (typeof options.baseURL !== "string") {
     return undefined;
   }
-  return normalizeBaseURL(options.baseURL);
+  if (pt === "anthropic") {
+    return normalizeBaseURL(options.baseURL);
+  }
+  return options.baseURL;
 };
 
 // ── Config resolution ──────────────────────────────────────────────────
 
-const extractCredentials = (provider: ProviderData): ProviderCredentials | null => {
+const extractCredentials = (
+  provider: ProviderData,
+  pt: ProviderType,
+): ProviderCredentials | null => {
   const apiKey = provider.key ?? extractApiKey(provider.options);
   if (!apiKey) {
     return null;
   }
-  return { apiKey, baseURL: extractBaseURL(provider.options) };
+  return { apiKey, baseURL: extractBaseURL(provider.options, pt) };
 };
 
 interface ScanResult {
@@ -96,7 +102,7 @@ const processProviderModel = (
   const accumulated = state[pt];
 
   if (!accumulated.credentials) {
-    accumulated.credentials = extractCredentials(provider);
+    accumulated.credentials = extractCredentials(provider, pt);
   }
 
   const option = getWebsearchOption(model);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,15 @@
-import { ANTHROPIC_NPM_PACKAGE, WEBSEARCH_ALWAYS, WEBSEARCH_AUTO } from "./constants.js";
-import { AnthropicCredentials, ProviderResolution } from "./types.js";
+import {
+  ANTHROPIC_NPM_PACKAGE,
+  OPENAI_NPM_PACKAGE,
+  WEBSEARCH_ALWAYS,
+  WEBSEARCH_AUTO,
+} from "./constants.js";
+import {
+  ProviderCredentials,
+  ProviderResolution,
+  ProviderResolutionMap,
+  ProviderType,
+} from "./types.js";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -14,6 +24,19 @@ interface ProviderData {
 
 const isAnthropicProvider = (model: { api: { npm: string } }): boolean =>
   model.api.npm === ANTHROPIC_NPM_PACKAGE;
+
+const isOpenAIProvider = (model: { api: { npm: string } }): boolean =>
+  model.api.npm === OPENAI_NPM_PACKAGE;
+
+const detectProviderType = (model: { api: { npm: string } }): ProviderType | null => {
+  if (isAnthropicProvider(model)) {
+    return "anthropic";
+  }
+  if (isOpenAIProvider(model)) {
+    return "openai";
+  }
+  return null;
+};
 
 const getWebsearchOption = (model: { options: Record<string, unknown> }): string | null => {
   const value = model.options.websearch;
@@ -41,7 +64,7 @@ const extractBaseURL = (options: Record<string, unknown>): string | undefined =>
 
 // ── Config resolution ──────────────────────────────────────────────────
 
-const extractCredentials = (provider: ProviderData): AnthropicCredentials | null => {
+const extractCredentials = (provider: ProviderData): ProviderCredentials | null => {
   const apiKey = provider.key ?? extractApiKey(provider.options);
   if (!apiKey) {
     return null;
@@ -50,19 +73,27 @@ const extractCredentials = (provider: ProviderData): AnthropicCredentials | null
 };
 
 interface ScanResult {
-  credentials: AnthropicCredentials | null;
+  credentials: ProviderCredentials | null;
   fallbackModel?: string;
   lockedModel?: string;
+}
+
+interface ScanState {
+  anthropic: ScanResult;
+  openai: ScanResult;
 }
 
 const processProviderModel = (
   provider: ProviderData,
   model: { api: { npm: string }; id: string; options: Record<string, unknown> },
-  accumulated: ScanResult,
+  state: ScanState,
 ): void => {
-  if (!isAnthropicProvider(model)) {
+  const pt = detectProviderType(model);
+  if (!pt) {
     return;
   }
+
+  const accumulated = state[pt];
 
   if (!accumulated.credentials) {
     accumulated.credentials = extractCredentials(provider);
@@ -77,47 +108,65 @@ const processProviderModel = (
   }
 };
 
-const scanProviderModels = (provider: ProviderData, accumulated: ScanResult): void => {
+const scanProviderModels = (provider: ProviderData, state: ScanState): void => {
   for (const model of Object.values(provider.models)) {
-    processProviderModel(provider, model, accumulated);
+    processProviderModel(provider, model, state);
   }
 };
-/**
- * Scan providers for Anthropic credentials and any websearch-tagged models.
- *
- * Resolution priority:
- * - `lockedModel`:   first model with `"websearch": "always"` (hard lock)
- * - `fallbackModel`: first model with `"websearch": "auto"`   (soft fallback)
- * - `credentials`:   API key + optional baseURL from the first Anthropic provider
- *
- * Returns `null` if no Anthropic provider with a valid API key is found.
- */
-const resolveFromProviders = (providers: ProviderData[]): ProviderResolution | null => {
-  const result: ScanResult = { credentials: null };
 
-  for (const provider of providers) {
-    scanProviderModels(provider, result);
-  }
-
-  if (!result.credentials) {
+const buildResolution = (scan: ScanResult, pt: ProviderType): ProviderResolution | null => {
+  if (!scan.credentials) {
     return null;
   }
-
   return {
-    credentials: result.credentials,
-    fallbackModel: result.fallbackModel,
-    lockedModel: result.lockedModel,
+    credentials: scan.credentials,
+    fallbackModel: scan.fallbackModel,
+    lockedModel: scan.lockedModel,
+    providerType: pt,
   };
+};
+
+/**
+ * Scan providers for Anthropic and OpenAI credentials and any websearch-tagged models.
+ *
+ * Resolution priority (per provider):
+ * - `lockedModel`:   first model with `"websearch": "always"` (hard lock)
+ * - `fallbackModel`: first model with `"websearch": "auto"`   (soft fallback)
+ * - `credentials`:   API key + optional baseURL from the first matching provider
+ *
+ * Returns a map with optional entries for each supported provider type.
+ */
+const resolveFromProviders = (providers: ProviderData[]): ProviderResolutionMap => {
+  const state: ScanState = {
+    anthropic: { credentials: null },
+    openai: { credentials: null },
+  };
+
+  for (const provider of providers) {
+    scanProviderModels(provider, state);
+  }
+
+  const result: ProviderResolutionMap = {};
+  const anthropic = buildResolution(state.anthropic, "anthropic");
+  if (anthropic) {
+    result.anthropic = anthropic;
+  }
+  const openai = buildResolution(state.openai, "openai");
+  if (openai) {
+    result.openai = openai;
+  }
+
+  return result;
 };
 
 // ── Error formatting ───────────────────────────────────────────────────
 
 const formatNoProviderError = (): string =>
-  `Error: web-search requires an Anthropic provider.
+  `Error: web-search requires an Anthropic or OpenAI provider.
 
-No Anthropic provider with a valid API key was found in your opencode.json configuration.
+No supported provider with a valid API key was found in your opencode.json configuration.
 
-To fix this, add an Anthropic provider to your opencode.json:
+To fix this, add an Anthropic or OpenAI provider to your opencode.json:
 
 {
   "provider": {
@@ -129,19 +178,31 @@ To fix this, add an Anthropic provider to your opencode.json:
   }
 }
 
+Or:
+
+{
+  "provider": {
+    "openai": {
+      "options": {
+        "apiKey": "{env:OPENAI_API_KEY}"
+      }
+    }
+  }
+}
+
 Steps:
 1. Open your opencode.json (project root, .opencode/, or ~/.config/opencode/)
-2. Ensure you have an Anthropic provider configured with a valid API key
+2. Ensure you have an Anthropic or OpenAI provider configured with a valid API key
 3. Restart OpenCode to pick up the configuration change`;
 
-const formatNonAnthropicError = (activeModelID: string): string =>
+const formatUnsupportedProviderError = (activeModelID: string): string =>
   `Error: your current model (${activeModelID}) does not support web search.
 
-Web search uses Anthropic's server-side web_search tool, which only works with Anthropic models.
+Web search requires an Anthropic or OpenAI model.
 
 You can either:
-1. Switch to an Anthropic model (e.g. claude-sonnet-4-5)
-2. Set \`"websearch": "auto"\` on an Anthropic model to use it as a fallback:
+1. Switch to a supported model (e.g. claude-sonnet-4-5 or gpt-4o)
+2. Set \`"websearch": "auto"\` on a supported model to use it as a fallback:
 
 {
   "provider": {
@@ -159,4 +220,9 @@ You can either:
 
 Or set \`"websearch": "always"\` to always use that model for web search regardless of your active model.`;
 
-export { formatNoProviderError, formatNonAnthropicError, ProviderData, resolveFromProviders };
+export {
+  formatNoProviderError,
+  formatUnsupportedProviderError,
+  ProviderData,
+  resolveFromProviders,
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,11 +1,11 @@
 // ── Constants ──────────────────────────────────────────────────────────
 
 const ANTHROPIC_NPM_PACKAGE = "@ai-sdk/anthropic";
-const DEFAULT_SEARCH_USES = 8;
 const EMPTY_LENGTH = 0;
 const MAX_RESPONSE_TOKENS = 16_000;
 const MIN_QUERY_LENGTH = 2;
 const MONTH_OFFSET = 1;
+const OPENAI_NPM_PACKAGE = "@ai-sdk/openai";
 const PAD_LENGTH = 2;
 const SEARCH_SYSTEM_PROMPT = "You are an assistant for performing a web search tool use";
 const WEBSEARCH_ALWAYS = "always";
@@ -13,11 +13,11 @@ const WEBSEARCH_AUTO = "auto";
 
 export {
   ANTHROPIC_NPM_PACKAGE,
-  DEFAULT_SEARCH_USES,
   EMPTY_LENGTH,
   MAX_RESPONSE_TOKENS,
   MIN_QUERY_LENGTH,
   MONTH_OFFSET,
+  OPENAI_NPM_PACKAGE,
   PAD_LENGTH,
   SEARCH_SYSTEM_PROMPT,
   WEBSEARCH_ALWAYS,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,9 +4,7 @@ const ANTHROPIC_NPM_PACKAGE = "@ai-sdk/anthropic";
 const EMPTY_LENGTH = 0;
 const MAX_RESPONSE_TOKENS = 16_000;
 const MIN_QUERY_LENGTH = 2;
-const MONTH_OFFSET = 1;
 const OPENAI_NPM_PACKAGE = "@ai-sdk/openai";
-const PAD_LENGTH = 2;
 const SEARCH_SYSTEM_PROMPT = "You are an assistant for performing a web search tool use";
 const WEBSEARCH_ALWAYS = "always";
 const WEBSEARCH_AUTO = "auto";
@@ -16,9 +14,7 @@ export {
   EMPTY_LENGTH,
   MAX_RESPONSE_TOKENS,
   MIN_QUERY_LENGTH,
-  MONTH_OFFSET,
   OPENAI_NPM_PACKAGE,
-  PAD_LENGTH,
   SEARCH_SYSTEM_PROMPT,
   WEBSEARCH_ALWAYS,
   WEBSEARCH_AUTO,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,16 +1,6 @@
-import { MONTH_OFFSET, PAD_LENGTH } from "./constants.js";
-
 // ── Helpers ────────────────────────────────────────────────────────────
-
-const getTodayDate = (): string => {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + MONTH_OFFSET).padStart(PAD_LENGTH, "0");
-  const day = String(now.getDate()).padStart(PAD_LENGTH, "0");
-  return `${year}-${month}-${day}`;
-};
 
 const getCurrentMonthYear = (): string =>
   new Date().toLocaleDateString("en-US", { month: "long", year: "numeric" });
 
-export { getCurrentMonthYear, getTodayDate };
+export { getCurrentMonthYear };

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,10 +37,12 @@ const detectActiveProviderType = (
   for (const provider of providers) {
     for (const model of Object.values(provider.models)) {
       if (model.id !== active.modelID) {
-        // oxlint-disable-next-line no-empty -- skip non-matching models
-      } else if (model.api.npm === ANTHROPIC_NPM_PACKAGE) {
+        continue;
+      }
+      if (model.api.npm === ANTHROPIC_NPM_PACKAGE) {
         return "anthropic";
-      } else if (model.api.npm === OPENAI_NPM_PACKAGE) {
+      }
+      if (model.api.npm === OPENAI_NPM_PACKAGE) {
         return "openai";
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,67 +1,159 @@
-import { ANTHROPIC_NPM_PACKAGE, MIN_QUERY_LENGTH } from "./constants.js";
-import { ActiveModel, ProviderResolution, SearchConfig } from "./types.js";
+import { ANTHROPIC_NPM_PACKAGE, MIN_QUERY_LENGTH, OPENAI_NPM_PACKAGE } from "./constants.js";
+import {
+  ActiveModel,
+  ProviderResolution,
+  ProviderResolutionMap,
+  ProviderType,
+  SearchConfig,
+} from "./types.js";
 import { Plugin, tool } from "@opencode-ai/plugin";
 import {
   ProviderData,
   formatNoProviderError,
-  formatNonAnthropicError,
+  formatUnsupportedProviderError,
   resolveFromProviders,
 } from "./config.js";
-import { executeSearch, formatErrorMessage } from "./providers/anthropic.js";
+import {
+  executeSearch as executeAnthropicSearch,
+  formatErrorMessage as formatAnthropicError,
+} from "./providers/anthropic.js";
+import {
+  executeSearch as executeOpenAISearch,
+  formatErrorMessage as formatOpenAIError,
+} from "./providers/openai.js";
 
 import { getCurrentMonthYear } from "./helpers.js";
 
-// ── Model resolution ───────────────────────────────────────────────────
+// ── Provider detection ─────────────────────────────────────────────────
 
-/**
- * Determine the model to use for a web search call.
- *
- * Priority:
- * 1. Locked model (`"websearch": "always"`) — always wins
- * 2. Active model if it's Anthropic — use the model the user is chatting with
- * 3. Fallback model (`"websearch": "auto"`) — when the active model is non-Anthropic
- * 4. Error — active model is non-Anthropic and no fallback configured
- */
-const resolveSearchModel = (
-  resolution: ProviderResolution,
+const detectActiveProviderType = (
   active: ActiveModel | undefined,
-): string | null => {
-  if (resolution.lockedModel) {
-    return resolution.lockedModel;
+  providers: ProviderData[],
+): ProviderType | null => {
+  if (!active) {
+    return null;
   }
 
-  if (active) {
-    return active.modelID;
-  }
-
-  if (resolution.fallbackModel) {
-    return resolution.fallbackModel;
+  for (const provider of providers) {
+    for (const model of Object.values(provider.models)) {
+      if (model.id !== active.modelID) {
+        // oxlint-disable-next-line no-empty -- skip non-matching models
+      } else if (model.api.npm === ANTHROPIC_NPM_PACKAGE) {
+        return "anthropic";
+      } else if (model.api.npm === OPENAI_NPM_PACKAGE) {
+        return "openai";
+      }
+    }
   }
 
   return null;
 };
 
-const isAnthropicActive = (active: ActiveModel | undefined, providers: ProviderData[]): boolean => {
-  if (!active) {
-    return false;
+// ── Model resolution ───────────────────────────────────────────────────
+
+interface ResolvedProvider {
+  config: SearchConfig;
+  providerType: ProviderType;
+}
+
+const buildSearchConfig = (resolution: ProviderResolution, modelID: string): SearchConfig => ({
+  apiKey: resolution.credentials.apiKey,
+  baseURL: resolution.credentials.baseURL,
+  model: modelID,
+});
+
+/**
+ * Resolve the locked model for a given provider resolution.
+ * Returns a ResolvedProvider if a locked model is set, otherwise null.
+ */
+const resolveLockedModel = (resolutions: ProviderResolutionMap): ResolvedProvider | null => {
+  if (resolutions.anthropic?.lockedModel) {
+    return {
+      config: buildSearchConfig(resolutions.anthropic, resolutions.anthropic.lockedModel),
+      providerType: "anthropic",
+    };
+  }
+  if (resolutions.openai?.lockedModel) {
+    return {
+      config: buildSearchConfig(resolutions.openai, resolutions.openai.lockedModel),
+      providerType: "openai",
+    };
+  }
+  return null;
+};
+
+/**
+ * Resolve using the active model's provider directly.
+ */
+const resolveActiveModel = (
+  activeType: ProviderType,
+  active: ActiveModel,
+  resolutions: ProviderResolutionMap,
+): ResolvedProvider | null => {
+  const resolution = resolutions[activeType];
+  if (!resolution) {
+    return null;
   }
 
-  for (const provider of providers) {
-    for (const model of Object.values(provider.models)) {
-      if (model.id === active.modelID && model.api.npm === ANTHROPIC_NPM_PACKAGE) {
-        return true;
-      }
+  return {
+    config: buildSearchConfig(resolution, active.modelID),
+    providerType: activeType,
+  };
+};
+
+/**
+ * Resolve a fallback model from any provider with `"websearch": "auto"`.
+ */
+const resolveFallbackModel = (resolutions: ProviderResolutionMap): ResolvedProvider | null => {
+  if (resolutions.anthropic?.fallbackModel) {
+    return {
+      config: buildSearchConfig(resolutions.anthropic, resolutions.anthropic.fallbackModel),
+      providerType: "anthropic",
+    };
+  }
+  if (resolutions.openai?.fallbackModel) {
+    return {
+      config: buildSearchConfig(resolutions.openai, resolutions.openai.fallbackModel),
+      providerType: "openai",
+    };
+  }
+  return null;
+};
+
+/**
+ * Determine which provider and model to use for a web search call.
+ *
+ * Priority:
+ * 1. Locked model (`"websearch": "always"`) from any provider — always wins
+ * 2. Active model if it belongs to a supported provider — use directly
+ * 3. Fallback model (`"websearch": "auto"`) from any provider — when active is unsupported
+ * 4. null — no usable provider/model found
+ */
+const resolveSearchProvider = (
+  resolutions: ProviderResolutionMap,
+  active: ActiveModel | undefined,
+  activeType: ProviderType | null,
+): ResolvedProvider | null => {
+  const locked = resolveLockedModel(resolutions);
+  if (locked) {
+    return locked;
+  }
+
+  if (activeType && active) {
+    const resolved = resolveActiveModel(activeType, active, resolutions);
+    if (resolved) {
+      return resolved;
     }
   }
 
-  return false;
+  return resolveFallbackModel(resolutions);
 };
 
 // ── Lazy provider resolution ───────────────────────────────────────────
 
 interface ProviderState {
   list: ProviderData[];
-  resolution: ProviderResolution | null;
+  resolutions: ProviderResolutionMap;
 }
 
 const resolveProviderState = async (client: {
@@ -69,19 +161,31 @@ const resolveProviderState = async (client: {
 }): Promise<ProviderState> => {
   const { data } = await client.config.providers();
   if (!data) {
-    return { list: [], resolution: null };
+    return { list: [], resolutions: {} };
   }
   const list = data.providers as ProviderData[];
-  return { list, resolution: resolveFromProviders(list) };
+  return { list, resolutions: resolveFromProviders(list) };
 };
 
-// ── Search execution ───────────────────────────────────────────────────
+const hasAnyProvider = (resolutions: ProviderResolutionMap): boolean =>
+  resolutions.anthropic !== undefined || resolutions.openai !== undefined;
 
-const buildSearchConfig = (resolution: ProviderResolution, modelID: string): SearchConfig => ({
-  apiKey: resolution.credentials.apiKey,
-  baseURL: resolution.credentials.baseURL,
-  model: modelID,
-});
+// ── Search dispatch ────────────────────────────────────────────────────
+
+const dispatchSearch = async (resolved: ResolvedProvider, query: string): Promise<string> => {
+  const args = { query };
+  if (resolved.providerType === "anthropic") {
+    return executeAnthropicSearch(resolved.config, args);
+  }
+  return executeOpenAISearch(resolved.config, args);
+};
+
+const dispatchErrorMessage = (providerType: ProviderType, error: unknown): string => {
+  if (providerType === "anthropic") {
+    return formatAnthropicError(error);
+  }
+  return formatOpenAIError(error);
+};
 
 // ── Plugin ─────────────────────────────────────────────────────────────
 
@@ -103,14 +207,6 @@ export default (async (input) => {
     tool: {
       "web-search": tool({
         args: {
-          allowed_domains: tool.schema
-            .array(tool.schema.string())
-            .optional()
-            .describe("Only include search results from these domains"),
-          blocked_domains: tool.schema
-            .array(tool.schema.string())
-            .optional()
-            .describe("Never include search results from these domains"),
           query: tool.schema.string().min(MIN_QUERY_LENGTH).describe("The search query to use"),
         },
         description: `- Allows OpenCode to search the web and use the results to inform responses
@@ -132,7 +228,7 @@ CRITICAL REQUIREMENT - You MUST follow this:
     - [Source Title 2](https://example.com/2)
 
 Usage notes:
-  - Domain filtering is supported to include or block specific websites
+  - Supports Anthropic and OpenAI providers
 
 IMPORTANT - Use the correct year in search queries:
   - It is currently ${getCurrentMonthYear()}. You MUST use this when searching for recent information, documentation, or current events.
@@ -143,28 +239,23 @@ IMPORTANT - Use the correct year in search queries:
             state = await resolveProviderState(input.client);
           }
 
-          if (!state.resolution) {
+          if (!hasAnyProvider(state.resolutions)) {
             return formatNoProviderError();
           }
 
-          if (args.allowed_domains && args.blocked_domains) {
-            return "Error: Cannot specify both allowed_domains and blocked_domains.";
-          }
-
           const active = activeModels.get(context.sessionID);
-          const modelID = resolveSearchModel(
-            state.resolution,
-            isAnthropicActive(active, state.list) ? active : undefined,
-          );
+          const activeType = detectActiveProviderType(active, state.list);
 
-          if (!modelID) {
-            return formatNonAnthropicError(active?.modelID ?? "unknown");
+          const resolved = resolveSearchProvider(state.resolutions, active, activeType);
+
+          if (!resolved) {
+            return formatUnsupportedProviderError(active?.modelID ?? "unknown");
           }
 
           try {
-            return await executeSearch(buildSearchConfig(state.resolution, modelID), args);
+            return await dispatchSearch(resolved, args.query);
           } catch (error) {
-            return formatErrorMessage(error);
+            return dispatchErrorMessage(resolved.providerType, error);
           }
         },
       }),

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,6 +1,6 @@
 import Anthropic, { APIError } from "@anthropic-ai/sdk";
 import { EMPTY_LENGTH, MAX_RESPONSE_TOKENS, SEARCH_SYSTEM_PROMPT } from "../constants.js";
-import { SearchArgs, SearchConfig } from "../types.js";
+import { SearchArgs, SearchConfig, SearchHit, StructuredSearchResponse } from "../types.js";
 
 // ── Anthropic-specific types ────────────────────────────────────────────
 
@@ -28,18 +28,6 @@ type ContentBlock = { text: string; type: "text" } | ServerToolUse | WebSearchTo
 // ── Constants ──────────────────────────────────────────────────────────
 
 const DEFAULT_SEARCH_USES = 8;
-
-// ── Structured result types ─────────────────────────────────────────────
-
-interface SearchHit {
-  title: string;
-  url: string;
-}
-
-interface StructuredSearchResponse {
-  query: string;
-  results: (SearchHit[] | string)[];
-}
 
 // ── Response processing ─────────────────────────────────────────────────
 

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,11 +1,33 @@
 import Anthropic, { APIError } from "@anthropic-ai/sdk";
-import { ContentBlock, SearchConfig, WebSearchResult } from "../types.js";
-import {
-  DEFAULT_SEARCH_USES,
-  EMPTY_LENGTH,
-  MAX_RESPONSE_TOKENS,
-  SEARCH_SYSTEM_PROMPT,
-} from "../constants.js";
+import { EMPTY_LENGTH, MAX_RESPONSE_TOKENS, SEARCH_SYSTEM_PROMPT } from "../constants.js";
+import { SearchArgs, SearchConfig } from "../types.js";
+
+// ── Anthropic-specific types ────────────────────────────────────────────
+
+interface WebSearchResult {
+  title: string;
+  type: "web_search_result";
+  url: string;
+}
+
+interface WebSearchToolResult {
+  content: WebSearchResult[] | { error_code: string; type: "web_search_tool_result_error" };
+  tool_use_id: string;
+  type: "web_search_tool_result";
+}
+
+interface ServerToolUse {
+  id: string;
+  input: { query: string };
+  name: string;
+  type: "server_tool_use";
+}
+
+type ContentBlock = { text: string; type: "text" } | ServerToolUse | WebSearchToolResult;
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const DEFAULT_SEARCH_USES = 8;
 
 // ── Structured result types ─────────────────────────────────────────────
 
@@ -57,25 +79,11 @@ const processResponseBlocks = (
 
 // ── Search tool construction ───────────────────────────────────────────
 
-const buildWebSearchTool = (args: {
-  allowed_domains?: string[];
-  blocked_domains?: string[];
-}): Record<string, unknown> => {
-  const searchTool: Record<string, unknown> = {
-    max_uses: DEFAULT_SEARCH_USES,
-    name: "web_search",
-    type: "web_search_20250305",
-  };
-
-  if (args.allowed_domains?.length) {
-    searchTool.allowed_domains = args.allowed_domains;
-  }
-  if (args.blocked_domains?.length) {
-    searchTool.blocked_domains = args.blocked_domains;
-  }
-
-  return searchTool;
-};
+const buildWebSearchTool = (): Record<string, unknown> => ({
+  max_uses: DEFAULT_SEARCH_USES,
+  name: "web_search",
+  type: "web_search_20250305",
+});
 
 // ── Error formatting ───────────────────────────────────────────────────
 
@@ -101,16 +109,9 @@ const createAnthropicClient = (config: SearchConfig): Anthropic => {
   return new Anthropic(options);
 };
 
-const executeSearch = async (
-  config: SearchConfig,
-  args: {
-    allowed_domains?: string[];
-    blocked_domains?: string[];
-    query: string;
-  },
-): Promise<string> => {
+const executeSearch = async (config: SearchConfig, args: SearchArgs): Promise<string> => {
   const client = createAnthropicClient(config);
-  const webSearchTool = buildWebSearchTool(args);
+  const webSearchTool = buildWebSearchTool();
 
   const response = await client.messages.create({
     max_tokens: MAX_RESPONSE_TOKENS,

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -5,19 +5,7 @@ import {
   ResponseOutputMessage,
   ResponseOutputText,
 } from "openai/resources/responses/responses";
-import { SearchArgs, SearchConfig } from "../types.js";
-
-// ── Structured result types ─────────────────────────────────────────────
-
-interface SearchHit {
-  title: string;
-  url: string;
-}
-
-interface StructuredSearchResponse {
-  query: string;
-  results: (SearchHit[] | string)[];
-}
+import { SearchArgs, SearchConfig, SearchHit, StructuredSearchResponse } from "../types.js";
 
 // ── Response processing ─────────────────────────────────────────────────
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,0 +1,123 @@
+import { EMPTY_LENGTH, MAX_RESPONSE_TOKENS, SEARCH_SYSTEM_PROMPT } from "../constants.js";
+import OpenAI, { APIError } from "openai";
+import {
+  ResponseOutputItem,
+  ResponseOutputMessage,
+  ResponseOutputText,
+} from "openai/resources/responses/responses";
+import { SearchArgs, SearchConfig } from "../types.js";
+
+// ── Structured result types ─────────────────────────────────────────────
+
+interface SearchHit {
+  title: string;
+  url: string;
+}
+
+interface StructuredSearchResponse {
+  query: string;
+  results: (SearchHit[] | string)[];
+}
+
+// ── Response processing ─────────────────────────────────────────────────
+
+const extractCitations = (annotations: ResponseOutputText["annotations"]): SearchHit[] => {
+  const seen = new Set<string>();
+  const hits: SearchHit[] = [];
+
+  for (const annotation of annotations) {
+    if (annotation.type !== "url_citation") {
+      // oxlint-disable-next-line no-empty -- skip non-citation annotations
+    } else if (!seen.has(annotation.url)) {
+      seen.add(annotation.url);
+      hits.push({ title: annotation.title, url: annotation.url });
+    }
+  }
+
+  return hits;
+};
+
+const collectCitations = (items: ResponseOutputItem[]): SearchHit[] => {
+  const allHits: SearchHit[] = [];
+
+  for (const item of items) {
+    if (item.type !== "message") {
+      // oxlint-disable-next-line no-empty -- skip non-message items
+    } else {
+      const message = item as ResponseOutputMessage;
+      for (const part of message.content) {
+        if (part.type === "output_text" && part.annotations.length > EMPTY_LENGTH) {
+          const hits = extractCitations(part.annotations);
+          for (const hit of hits) {
+            allHits.push(hit);
+          }
+        }
+      }
+    }
+  }
+
+  return allHits;
+};
+
+const buildStructuredResponse = (
+  query: string,
+  outputText: string,
+  items: ResponseOutputItem[],
+): StructuredSearchResponse => {
+  const results: (SearchHit[] | string)[] = [];
+
+  if (outputText.length > EMPTY_LENGTH) {
+    results.push(outputText);
+  }
+
+  const citations = collectCitations(items);
+  if (citations.length > EMPTY_LENGTH) {
+    results.push(citations);
+  }
+
+  return { query, results };
+};
+
+// ── Error formatting ───────────────────────────────────────────────────
+
+const formatErrorMessage = (error: unknown): string => {
+  if (error instanceof APIError) {
+    return `OpenAI API error: ${error.message} (status: ${error.status})`;
+  }
+  if (error instanceof Error) {
+    return `Error performing web search: ${error.message}`;
+  }
+  return `Error performing web search: ${String(error)}`;
+};
+
+// ── Client and execution ───────────────────────────────────────────────
+
+const createOpenAIClient = (config: SearchConfig): OpenAI => {
+  const options: { apiKey: string; baseURL?: string } = {
+    apiKey: config.apiKey,
+  };
+  if (config.baseURL) {
+    options.baseURL = config.baseURL;
+  }
+  return new OpenAI(options);
+};
+
+const WEB_SEARCH_TOOL: OpenAI.Responses.WebSearchTool = { type: "web_search" };
+
+const executeSearch = async (config: SearchConfig, args: SearchArgs): Promise<string> => {
+  const client = createOpenAIClient(config);
+
+  const response = await client.responses.create({
+    input: `Perform a web search for the query: ${args.query}`,
+    instructions: SEARCH_SYSTEM_PROMPT,
+    max_output_tokens: MAX_RESPONSE_TOKENS,
+    model: config.model,
+    tools: [WEB_SEARCH_TOOL],
+  });
+
+  const structured = buildStructuredResponse(args.query, response.output_text, response.output);
+
+  return JSON.stringify(structured);
+};
+
+export { executeSearch, formatErrorMessage };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,18 @@
 // ── Shared Types ───────────────────────────────────────────────────────
 
 /**
- * Credentials needed to call the Anthropic API.
- * Resolved from any Anthropic provider in the OpenCode config.
+ * Credentials needed to call a provider API (Anthropic or OpenAI).
+ * Resolved from the provider's configuration in opencode.json.
  */
-interface AnthropicCredentials {
+interface ProviderCredentials {
   apiKey: string;
   baseURL?: string;
 }
+
+/**
+ * Identifies which provider type a resolution belongs to.
+ */
+type ProviderType = "anthropic" | "openai";
 
 /**
  * Fully resolved config for a single web search call:
@@ -20,15 +25,25 @@ interface SearchConfig {
 }
 
 /**
- * The result of scanning all providers at startup:
- * - `credentials`: API key + optional base URL from the first Anthropic provider
+ * The result of scanning a single provider at startup:
+ * - `credentials`: API key + optional base URL
  * - `lockedModel`: model ID if a model has `websearch: "always"` (hard lock)
  * - `fallbackModel`: model ID if a model has `"websearch": "auto"` (soft fallback)
+ * - `providerType`: which provider this resolution belongs to
  */
 interface ProviderResolution {
-  credentials: AnthropicCredentials;
+  credentials: ProviderCredentials;
   fallbackModel?: string;
   lockedModel?: string;
+  providerType: ProviderType;
+}
+
+/**
+ * Map of provider resolutions, one per supported provider type.
+ */
+interface ProviderResolutionMap {
+  anthropic?: ProviderResolution;
+  openai?: ProviderResolution;
 }
 
 // ── Active Model ───────────────────────────────────────────────────────
@@ -42,36 +57,21 @@ interface ActiveModel {
   providerID: string;
 }
 
-// ── Anthropic Response Types ───────────────────────────────────────────
+// ── Tool Args ──────────────────────────────────────────────────────────
 
-interface WebSearchResult {
-  title: string;
-  type: "web_search_result";
-  url: string;
+/**
+ * Arguments accepted by the web-search tool.
+ */
+interface SearchArgs {
+  query: string;
 }
-
-interface WebSearchToolResult {
-  content: WebSearchResult[] | { error_code: string; type: "web_search_tool_result_error" };
-  tool_use_id: string;
-  type: "web_search_tool_result";
-}
-
-interface ServerToolUse {
-  id: string;
-  input: { query: string };
-  name: string;
-  type: "server_tool_use";
-}
-
-type ContentBlock = { text: string; type: "text" } | ServerToolUse | WebSearchToolResult;
 
 export {
   ActiveModel,
-  AnthropicCredentials,
-  ContentBlock,
+  ProviderCredentials,
   ProviderResolution,
+  ProviderResolutionMap,
+  ProviderType,
+  SearchArgs,
   SearchConfig,
-  ServerToolUse,
-  WebSearchResult,
-  WebSearchToolResult,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,26 @@ interface SearchArgs {
   query: string;
 }
 
+// ── Structured Result Types ────────────────────────────────────────────
+
+/**
+ * A single search result hit with a title and URL.
+ * Used by both Anthropic and OpenAI providers.
+ */
+interface SearchHit {
+  title: string;
+  url: string;
+}
+
+/**
+ * Structured response returned by a web search execution.
+ * Contains the original query and an array of results (text or citation hits).
+ */
+interface StructuredSearchResponse {
+  query: string;
+  results: (SearchHit[] | string)[];
+}
+
 export {
   ActiveModel,
   ProviderCredentials,
@@ -74,4 +94,6 @@ export {
   ProviderType,
   SearchArgs,
   SearchConfig,
+  SearchHit,
+  StructuredSearchResponse,
 };


### PR DESCRIPTION
## Summary

- Adds OpenAI as a second web search provider alongside Anthropic, generalizing config scanning, model resolution, and search dispatch to handle multiple provider types.
- OpenAI provider uses proper SDK types (`ResponseOutputItem`, `ResponseOutputText`) instead of custom interfaces with unsafe `as` casts, `response.output_text` for simplified text extraction, `instructions` parameter for system-level prompt separation, and `max_output_tokens` for cost parity with Anthropic.
- Refactors shared types (`ProviderCredentials`, `ProviderResolutionMap`, `ProviderType`) and moves Anthropic-specific response types into the Anthropic provider module.