### PR TITLE
feat: add GitHub Copilot web search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@ Web search plugin for [OpenCode](https://opencode.ai) that provides web search f
 
 ## Supported providers
 
-| Provider | SDK package | Search mechanism | Supported models |
-| -------- | ----------- | ---------------- | ---------------- |
-| Anthropic | `@ai-sdk/anthropic` | [Web search tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool) | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6` |
-| OpenAI | `@ai-sdk/openai` | [Responses API web search](https://platform.openai.com/docs/guides/tools-web-search) | `gpt-5.4`, _gpt-5.4-mini\*_, _gpt-5.4-nano\*_, _gpt-5\*_, _gpt-5-mini\*_, _gpt-4.1\*_, _gpt-4.1-mini\*_ |
-| GitHub Copilot | `@ai-sdk/github-copilot` | [Copilot model-native web search](https://github.blog/changelog/2026-02-25-improved-web-search-in-copilot-on-github-com/) | `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1`, `gpt-5.4-mini`, _gpt-5-mini\*_, _gpt-5.4\*_ |
+| Provider       | SDK package              | Search mechanism                                                                                                          | Notes                                                                                                                                                       |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Anthropic      | `@ai-sdk/anthropic`      | [Web search tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool)                          | This plugin uses Anthropic tool type `web_search_20250305`; model compatibility follows that tool version.                                                     |
+| OpenAI         | `@ai-sdk/openai`         | [Responses API web search](https://platform.openai.com/docs/guides/tools-web-search)                                      | Known unsupported: `gpt-4.1-nano`, and `gpt-5` with `reasoning.effort: "minimal"`.                                                                        |
+| GitHub Copilot | `@ai-sdk/github-copilot` | [Copilot model-native web search](https://github.blog/changelog/2026-02-25-improved-web-search-in-copilot-on-github-com/) | Requires `Copilot can search the web using model native search` to be enabled in GitHub Copilot settings. OpenAI-family models are working here; Claude models do not appear to work with Copilot built-in model-native search capabilities. |
 
-Models marked with \* are expected but currently untested in this repository.
-
-This model list is not exhaustive and can change as providers add, remove, or update model support.
+These limitations are based on current provider docs and can change over time.
 
 ## Install
 
@@ -28,7 +26,7 @@ OpenCode will install it automatically at startup.
 
 ## Configuration (optional)
 
-No configuration is needed if your active chat model belongs to a supported provider. To customize which model handles web searches, tag a model with `"websearch": "auto"` or `"websearch": "always"`.
+No configuration is needed if your active chat model supports the provider's native web search capability used by this plugin. To customize which model handles web searches, tag a model with `"websearch": "auto"` or `"websearch": "always"`.
 
 ### Model selection
 
@@ -37,7 +35,7 @@ The plugin chooses which model to use for each search:
 | Priority | Condition                                      | Behavior                                                                  |
 | -------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
 | 1        | A model is tagged `"always"`                   | That model is **always** used, regardless of what you're chatting with    |
-| 2        | Your active chat model is a supported provider | The active model is used directly -- no extra configuration needed        |
+| 2        | Your active chat model supports native web search | The active model is used directly -- no extra configuration needed        |
 | 3        | A model is tagged `"auto"`                     | That model is used as a **fallback** when the active model is unsupported |
 | 4        | None of the above                              | An error is returned                                                      |
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # opencode-websearch
 
-Web search plugin for [OpenCode](https://opencode.ai), inspired by Claude Code's built-in web search. Gives any OpenCode model access to real-time web results with source citations.
+Web search plugin for [OpenCode](https://opencode.ai) that provides web search functionality using each provider's native APIs, inspired by Claude Code's WebSearch tool.
 
 ## Supported providers
 
-| Provider  | SDK package         | Search mechanism                                                                                   |
-| --------- | ------------------- | -------------------------------------------------------------------------------------------------- |
-| Anthropic | `@ai-sdk/anthropic` | [`web_search` tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool) |
-| OpenAI    | `@ai-sdk/openai`    | [Responses API web search](https://platform.openai.com/docs/guides/tools-web-search)               |
+| Provider | SDK package | Search mechanism | Supported models |
+| -------- | ----------- | ---------------- | ---------------- |
+| Anthropic | `@ai-sdk/anthropic` | [Web search tool](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/web-search-tool) | `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6` |
+| OpenAI | `@ai-sdk/openai` | [Responses API web search](https://platform.openai.com/docs/guides/tools-web-search) | `gpt-5.4`, _gpt-5.4-mini\*_, _gpt-5.4-nano\*_, _gpt-5\*_, _gpt-5-mini\*_, _gpt-4.1\*_, _gpt-4.1-mini\*_ |
+| GitHub Copilot | `@ai-sdk/github-copilot` | [Copilot model-native web search](https://github.blog/changelog/2026-02-25-improved-web-search-in-copilot-on-github-com/) | `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1`, `gpt-5.4-mini`, _gpt-5-mini\*_, _gpt-5.4\*_ |
+
+Models marked with \* are expected but currently untested in this repository.
+
+This model list is not exhaustive and can change as providers add, remove, or update model support.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -28,20 +28,26 @@ OpenCode will install it automatically at startup.
 
 No configuration is needed if your active chat model supports the provider's native web search capability used by this plugin. To customize which model handles web searches, tag a model with `"websearch": "auto"` or `"websearch": "always"`.
 
+Important: `"auto"` is a provider-level fallback, not a model-level fallback.
+
 ### Model selection
 
 The plugin chooses which model to use for each search:
 
-| Priority | Condition                                      | Behavior                                                                  |
-| -------- | ---------------------------------------------- | ------------------------------------------------------------------------- |
-| 1        | A model is tagged `"always"`                   | That model is **always** used, regardless of what you're chatting with    |
-| 2        | Your active chat model supports native web search | The active model is used directly -- no extra configuration needed        |
-| 3        | A model is tagged `"auto"`                     | That model is used as a **fallback** when the active model is unsupported |
-| 4        | None of the above                              | An error is returned                                                      |
+| Priority | Condition                                                           | Behavior                                                               |
+| -------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1        | A model is tagged `"always"`                                        | That model is **always** used, regardless of what you're chatting with |
+| 2        | Active model is on a supported and configured provider              | The active model is used for web search                                |
+| 3        | Active model is on an unsupported provider, and a model is `"auto"` | The `"auto"` model is used as fallback                                |
+| 4        | None of the above                                                   | An error is returned                                                   |
 
-### `"auto"` mode (recommended)
+### `"auto"` mode (fallback)
 
-Use `"auto"` when you want web search to work seamlessly regardless of your active model. When your active model belongs to a supported provider, it's used directly; otherwise the tagged model kicks in as a fallback.
+Use `"auto"` to set a fallback model when your active model is on an unsupported provider.
+
+If your active model is on a supported provider, that active model is used, even if that specific model does not support web search.
+
+If you want one model to always handle web search, use `"always"`.
 
 ```json
 {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import {
   ANTHROPIC_NPM_PACKAGE,
+  COPILOT_NPM_PACKAGE,
   OPENAI_NPM_PACKAGE,
   WEBSEARCH_ALWAYS,
   WEBSEARCH_AUTO,
@@ -20,25 +21,35 @@ interface ProviderData {
   options: Record<string, unknown>;
 }
 
+interface ProviderModel {
+  api: { npm: string };
+  id: string;
+  options: Record<string, unknown>;
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────
 
-const isAnthropicProvider = (model: { api: { npm: string } }): boolean =>
+const isAnthropicProvider = (model: ProviderModel): boolean =>
   model.api.npm === ANTHROPIC_NPM_PACKAGE;
 
-const isOpenAIProvider = (model: { api: { npm: string } }): boolean =>
-  model.api.npm === OPENAI_NPM_PACKAGE;
+const isOpenAIProvider = (model: ProviderModel): boolean => model.api.npm === OPENAI_NPM_PACKAGE;
 
-const detectProviderType = (model: { api: { npm: string } }): ProviderType | null => {
+const isCopilotProvider = (model: ProviderModel): boolean => model.api.npm === COPILOT_NPM_PACKAGE;
+
+const detectProviderType = (model: ProviderModel): ProviderType | null => {
   if (isAnthropicProvider(model)) {
     return "anthropic";
   }
   if (isOpenAIProvider(model)) {
     return "openai";
   }
+  if (isCopilotProvider(model)) {
+    return "copilot";
+  }
   return null;
 };
 
-const getWebsearchOption = (model: { options: Record<string, unknown> }): string | null => {
+const getWebsearchOption = (model: ProviderModel): string | null => {
   const value = model.options.websearch;
   if (value === WEBSEARCH_ALWAYS || value === WEBSEARCH_AUTO) {
     return value;
@@ -86,12 +97,18 @@ interface ScanResult {
 
 interface ScanState {
   anthropic: ScanResult;
+  copilot: ScanResult;
   openai: ScanResult;
+}
+
+interface ProviderModelOverrides {
+  fallbackModel?: string;
+  lockedModel?: string;
 }
 
 const processProviderModel = (
   provider: ProviderData,
-  model: { api: { npm: string }; id: string; options: Record<string, unknown> },
+  model: ProviderModel,
   state: ScanState,
 ): void => {
   const pt = detectProviderType(model);
@@ -132,8 +149,39 @@ const buildResolution = (scan: ScanResult, pt: ProviderType): ProviderResolution
   };
 };
 
+const resolveModelOverrides = (
+  providers: ProviderData[],
+  pt: ProviderType,
+): ProviderModelOverrides => {
+  const overrides: ProviderModelOverrides = {};
+
+  for (const provider of providers) {
+    for (const model of Object.values(provider.models)) {
+      if (detectProviderType(model) !== pt) {
+        continue;
+      }
+      const option = getWebsearchOption(model);
+      if (option === WEBSEARCH_ALWAYS && !overrides.lockedModel) {
+        overrides.lockedModel = model.id;
+      }
+      if (option === WEBSEARCH_AUTO && !overrides.fallbackModel) {
+        overrides.fallbackModel = model.id;
+      }
+    }
+  }
+
+  return overrides;
+};
+
+const resolveCopilotModelHint = (): string =>
+  "gpt-5.3-codex, gpt-5.2-codex, gpt-5.2, gpt-5.1, gpt-5.4-mini";
+
+const resolveGeneralModelHint = (): string =>
+  "claude-sonnet-4-6, claude-opus-4-6, gpt-5.4, gpt-5.4-mini";
+
 /**
- * Scan providers for Anthropic and OpenAI credentials and any websearch-tagged models.
+ * Scan providers for Anthropic, OpenAI, and GitHub Copilot credentials
+ * and any websearch-tagged models.
  *
  * Resolution priority (per provider):
  * - `lockedModel`:   first model with `"websearch": "always"` (hard lock)
@@ -145,6 +193,7 @@ const buildResolution = (scan: ScanResult, pt: ProviderType): ProviderResolution
 const resolveFromProviders = (providers: ProviderData[]): ProviderResolutionMap => {
   const state: ScanState = {
     anthropic: { credentials: null },
+    copilot: { credentials: null },
     openai: { credentials: null },
   };
 
@@ -161,6 +210,10 @@ const resolveFromProviders = (providers: ProviderData[]): ProviderResolutionMap 
   if (openai) {
     result.openai = openai;
   }
+  const copilot = buildResolution(state.copilot, "copilot");
+  if (copilot) {
+    result.copilot = copilot;
+  }
 
   return result;
 };
@@ -168,7 +221,7 @@ const resolveFromProviders = (providers: ProviderData[]): ProviderResolutionMap 
 // ── Error formatting ───────────────────────────────────────────────────
 
 const formatNoProviderError = (): string =>
-  `Error: web-search requires an Anthropic or OpenAI provider.
+  `Error: web-search requires an Anthropic, OpenAI, or GitHub Copilot provider.
 
 No supported provider with a valid API key was found in your opencode.json configuration.
 
@@ -196,18 +249,22 @@ Or:
   }
 }
 
+Or, if you use GitHub Copilot, ensure you're signed in to Copilot in OpenCode.
+
 Steps:
 1. Open your opencode.json (project root, .opencode/, or ~/.config/opencode/)
-2. Ensure you have an Anthropic or OpenAI provider configured with a valid API key
+2. Ensure you have an Anthropic/OpenAI provider configured with a valid API key, or active GitHub Copilot auth
 3. Restart OpenCode to pick up the configuration change`;
 
 const formatUnsupportedProviderError = (activeModelID: string): string =>
   `Error: your current model (${activeModelID}) does not support web search.
 
-Web search requires an Anthropic or OpenAI model.
+Web search requires an Anthropic, OpenAI, or GitHub Copilot web-search-capable model.
+
+Known Copilot models that work with web search today include: ${resolveCopilotModelHint()}.
 
 You can either:
-1. Switch to a supported model (e.g. claude-sonnet-4-5 or gpt-4o)
+1. Switch to a supported model (e.g. ${resolveGeneralModelHint()})
 2. Set \`"websearch": "auto"\` on a supported model to use it as a fallback:
 
 {
@@ -230,5 +287,6 @@ export {
   formatNoProviderError,
   formatUnsupportedProviderError,
   ProviderData,
+  resolveModelOverrides,
   resolveFromProviders,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ import {
 interface ProviderData {
   id: string;
   key?: string;
-  models: Record<string, { api: { npm: string }; id: string; options: Record<string, unknown> }>;
+  models: Record<string, ProviderModel>;
   options: Record<string, unknown>;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,11 @@
 // ── Constants ──────────────────────────────────────────────────────────
 
 const ANTHROPIC_NPM_PACKAGE = "@ai-sdk/anthropic";
+const COPILOT_DEFAULT_BASE_URL = "https://api.githubcopilot.com";
+const COPILOT_INITIATOR = "user";
+const COPILOT_INTENT = "conversation-edits";
+const COPILOT_NPM_PACKAGE = "@ai-sdk/github-copilot";
+const COPILOT_USER_AGENT = "opencode-websearch";
 const EMPTY_LENGTH = 0;
 const MAX_RESPONSE_TOKENS = 16_000;
 const MIN_QUERY_LENGTH = 2;
@@ -11,6 +16,11 @@ const WEBSEARCH_AUTO = "auto";
 
 export {
   ANTHROPIC_NPM_PACKAGE,
+  COPILOT_DEFAULT_BASE_URL,
+  COPILOT_INITIATOR,
+  COPILOT_INTENT,
+  COPILOT_NPM_PACKAGE,
+  COPILOT_USER_AGENT,
   EMPTY_LENGTH,
   MAX_RESPONSE_TOKENS,
   MIN_QUERY_LENGTH,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-import { ANTHROPIC_NPM_PACKAGE, MIN_QUERY_LENGTH, OPENAI_NPM_PACKAGE } from "./constants.js";
+import {
+  ANTHROPIC_NPM_PACKAGE,
+  COPILOT_NPM_PACKAGE,
+  MIN_QUERY_LENGTH,
+  OPENAI_NPM_PACKAGE,
+} from "./constants.js";
 import {
   ActiveModel,
   ProviderResolution,
@@ -12,19 +17,50 @@ import {
   formatNoProviderError,
   formatUnsupportedProviderError,
   resolveFromProviders,
+  resolveModelOverrides,
 } from "./config.js";
 import {
   executeSearch as executeAnthropicSearch,
   formatErrorMessage as formatAnthropicError,
 } from "./providers/anthropic.js";
 import {
+  executeSearch as executeCopilotSearch,
+  formatErrorMessage as formatCopilotError,
+} from "./providers/copilot.js";
+import {
   executeSearch as executeOpenAISearch,
   formatErrorMessage as formatOpenAIError,
 } from "./providers/openai.js";
-
 import { getCurrentMonthYear } from "./helpers.js";
+import { resolveCopilotCredentials } from "./providers/copilot-auth.js";
 
 // ── Provider detection ─────────────────────────────────────────────────
+
+const detectProviderTypeFromNpm = (npmPackage: string): ProviderType | null => {
+  if (npmPackage === ANTHROPIC_NPM_PACKAGE) {
+    return "anthropic";
+  }
+  if (npmPackage === OPENAI_NPM_PACKAGE) {
+    return "openai";
+  }
+  if (npmPackage === COPILOT_NPM_PACKAGE) {
+    return "copilot";
+  }
+  return null;
+};
+
+const detectProviderTypeFromProviderID = (providerID: string): ProviderType | null => {
+  if (providerID.includes("github-copilot") || providerID.includes("copilot")) {
+    return "copilot";
+  }
+  if (providerID.includes("anthropic")) {
+    return "anthropic";
+  }
+  if (providerID.includes("openai")) {
+    return "openai";
+  }
+  return null;
+};
 
 const detectActiveProviderType = (
   active: ActiveModel | undefined,
@@ -35,20 +71,36 @@ const detectActiveProviderType = (
   }
 
   for (const provider of providers) {
+    if (provider.id !== active.providerID) {
+      continue;
+    }
+
+    for (const model of Object.values(provider.models)) {
+      const modelType = detectProviderTypeFromNpm(model.api.npm);
+      if (modelType) {
+        return modelType;
+      }
+    }
+
+    const providerType = detectProviderTypeFromProviderID(provider.id);
+    if (providerType) {
+      return providerType;
+    }
+  }
+
+  for (const provider of providers) {
     for (const model of Object.values(provider.models)) {
       if (model.id !== active.modelID) {
         continue;
       }
-      if (model.api.npm === ANTHROPIC_NPM_PACKAGE) {
-        return "anthropic";
-      }
-      if (model.api.npm === OPENAI_NPM_PACKAGE) {
-        return "openai";
+      const modelType = detectProviderTypeFromNpm(model.api.npm);
+      if (modelType) {
+        return modelType;
       }
     }
   }
 
-  return null;
+  return detectProviderTypeFromProviderID(active.providerID);
 };
 
 // ── Model resolution ───────────────────────────────────────────────────
@@ -79,6 +131,12 @@ const resolveLockedModel = (resolutions: ProviderResolutionMap): ResolvedProvide
     return {
       config: buildSearchConfig(resolutions.openai, resolutions.openai.lockedModel),
       providerType: "openai",
+    };
+  }
+  if (resolutions.copilot?.lockedModel) {
+    return {
+      config: buildSearchConfig(resolutions.copilot, resolutions.copilot.lockedModel),
+      providerType: "copilot",
     };
   }
   return null;
@@ -117,6 +175,12 @@ const resolveFallbackModel = (resolutions: ProviderResolutionMap): ResolvedProvi
     return {
       config: buildSearchConfig(resolutions.openai, resolutions.openai.fallbackModel),
       providerType: "openai",
+    };
+  }
+  if (resolutions.copilot?.fallbackModel) {
+    return {
+      config: buildSearchConfig(resolutions.copilot, resolutions.copilot.fallbackModel),
+      providerType: "copilot",
     };
   }
   return null;
@@ -158,19 +222,40 @@ interface ProviderState {
   resolutions: ProviderResolutionMap;
 }
 
-const resolveProviderState = async (client: {
-  config: { providers: () => Promise<{ data?: { providers: unknown[] } }> };
-}): Promise<ProviderState> => {
+const resolveProviderState = async (
+  client: {
+    config: { providers: () => Promise<{ data?: { providers: unknown[] } }> };
+    path: {
+      get: (options?: { query?: { directory?: string } }) => Promise<{ data?: { state?: string } }>;
+    };
+  },
+  directory: string,
+): Promise<ProviderState> => {
   const { data } = await client.config.providers();
   if (!data) {
     return { list: [], resolutions: {} };
   }
   const list = data.providers as ProviderData[];
-  return { list, resolutions: resolveFromProviders(list) };
+  const resolutions = resolveFromProviders(list);
+
+  const copilotCredentials = await resolveCopilotCredentials(client, directory);
+  if (copilotCredentials) {
+    const modelOverrides = resolveModelOverrides(list, "copilot");
+    resolutions.copilot = {
+      credentials: copilotCredentials,
+      fallbackModel: modelOverrides.fallbackModel,
+      lockedModel: modelOverrides.lockedModel,
+      providerType: "copilot",
+    };
+  }
+
+  return { list, resolutions };
 };
 
 const hasAnyProvider = (resolutions: ProviderResolutionMap): boolean =>
-  resolutions.anthropic !== undefined || resolutions.openai !== undefined;
+  resolutions.anthropic !== undefined ||
+  resolutions.copilot !== undefined ||
+  resolutions.openai !== undefined;
 
 // ── Search dispatch ────────────────────────────────────────────────────
 
@@ -179,12 +264,18 @@ const dispatchSearch = async (resolved: ResolvedProvider, query: string): Promis
   if (resolved.providerType === "anthropic") {
     return executeAnthropicSearch(resolved.config, args);
   }
+  if (resolved.providerType === "copilot") {
+    return executeCopilotSearch(resolved.config, args);
+  }
   return executeOpenAISearch(resolved.config, args);
 };
 
 const dispatchErrorMessage = (providerType: ProviderType, error: unknown): string => {
   if (providerType === "anthropic") {
     return formatAnthropicError(error);
+  }
+  if (providerType === "copilot") {
+    return formatCopilotError(error);
   }
   return formatOpenAIError(error);
 };
@@ -230,7 +321,7 @@ CRITICAL REQUIREMENT - You MUST follow this:
     - [Source Title 2](https://example.com/2)
 
 Usage notes:
-  - Supports Anthropic and OpenAI providers
+  - Supports Anthropic, OpenAI, and GitHub Copilot providers
 
 IMPORTANT - Use the correct year in search queries:
   - It is currently ${getCurrentMonthYear()}. You MUST use this when searching for recent information, documentation, or current events.
@@ -238,7 +329,7 @@ IMPORTANT - Use the correct year in search queries:
 
         async execute(args, context) {
           if (!state) {
-            state = await resolveProviderState(input.client);
+            state = await resolveProviderState(input.client, input.directory);
           }
 
           if (!hasAnyProvider(state.resolutions)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -321,8 +321,6 @@ CRITICAL REQUIREMENT - You MUST follow this:
     - [Source Title 2](https://example.com/2)
 
 Usage notes:
-  - Supports Anthropic, OpenAI, and GitHub Copilot providers
-
 IMPORTANT - Use the correct year in search queries:
   - It is currently ${getCurrentMonthYear()}. You MUST use this when searching for recent information, documentation, or current events.
   - Example: If the user asks for "latest React docs", search for "React documentation" with the current year, NOT last year`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,43 @@ const detectProviderTypeFromProviderID = (providerID: string): ProviderType | nu
   return null;
 };
 
+const detectProviderTypeFromProviderModels = (
+  models: ProviderData["models"],
+  activeModelID: string,
+): ProviderType | null => {
+  const providerModels = Object.values(models);
+
+  for (const model of providerModels) {
+    if (model.id !== activeModelID) {
+      continue;
+    }
+
+    const modelType = detectProviderTypeFromNpm(model.api.npm);
+    if (modelType) {
+      return modelType;
+    }
+  }
+
+  let detectedType: ProviderType | null = null;
+  for (const model of providerModels) {
+    const modelType = detectProviderTypeFromNpm(model.api.npm);
+    if (!modelType) {
+      continue;
+    }
+
+    if (!detectedType) {
+      detectedType = modelType;
+      continue;
+    }
+
+    if (detectedType !== modelType) {
+      return null;
+    }
+  }
+
+  return detectedType;
+};
+
 const detectActiveProviderType = (
   active: ActiveModel | undefined,
   providers: ProviderData[],
@@ -75,11 +112,12 @@ const detectActiveProviderType = (
       continue;
     }
 
-    for (const model of Object.values(provider.models)) {
-      const modelType = detectProviderTypeFromNpm(model.api.npm);
-      if (modelType) {
-        return modelType;
-      }
+    const providerModelsType = detectProviderTypeFromProviderModels(
+      provider.models,
+      active.modelID,
+    );
+    if (providerModelsType) {
+      return providerModelsType;
     }
 
     const providerType = detectProviderTypeFromProviderID(provider.id);

--- a/src/providers/copilot-auth.ts
+++ b/src/providers/copilot-auth.ts
@@ -1,0 +1,157 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, sep } from "node:path";
+
+import { COPILOT_DEFAULT_BASE_URL } from "../constants.js";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface CopilotAuthEntry {
+  enterpriseUrl?: string;
+  refresh?: string;
+  type?: string;
+}
+
+interface CopilotCredentials {
+  apiKey: string;
+  baseURL?: string;
+}
+
+interface PathClient {
+  path: {
+    get: (options?: { query?: { directory?: string } }) => Promise<{ data?: { state?: string } }>;
+  };
+}
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const AUTH_FILE_NAME = "auth.json";
+const COPILOT_AUTH_KEY = "github-copilot";
+const EMPTY_LENGTH = 0;
+const OPENCODE_DIR = "opencode";
+const REMOVE_LAST_CHARACTER = -1;
+const SHARE_DIR = "share";
+const STATE_DIR = "state";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const normalizeDomain = (value: string): string => {
+  let domain = value.trim();
+
+  if (domain.startsWith("https://")) {
+    domain = domain.slice("https://".length);
+  } else if (domain.startsWith("http://")) {
+    domain = domain.slice("http://".length);
+  }
+
+  if (domain.endsWith("/")) {
+    domain = domain.slice(EMPTY_LENGTH, REMOVE_LAST_CHARACTER);
+  }
+
+  return domain;
+};
+
+const buildCopilotBaseURL = (enterpriseUrl: string | undefined): string => {
+  if (!enterpriseUrl) {
+    return COPILOT_DEFAULT_BASE_URL;
+  }
+
+  const domain = normalizeDomain(enterpriseUrl);
+  if (domain.length === EMPTY_LENGTH) {
+    return COPILOT_DEFAULT_BASE_URL;
+  }
+
+  return `https://copilot-api.${domain}`;
+};
+
+const resolveAuthPathFromStatePath = (statePath: string | undefined): string | null => {
+  if (!statePath) {
+    return null;
+  }
+
+  const stateMarker = `${sep}${STATE_DIR}${sep}${OPENCODE_DIR}`;
+  if (!statePath.endsWith(stateMarker)) {
+    return null;
+  }
+
+  const dataMarker = `${sep}${SHARE_DIR}${sep}${OPENCODE_DIR}`;
+  const dataPath = statePath.replace(stateMarker, dataMarker);
+  return join(dataPath, AUTH_FILE_NAME);
+};
+
+const resolveAuthPath = async (client: PathClient, directory: string): Promise<string | null> => {
+  const response = await client.path.get({ query: { directory } });
+  if (!response.data) {
+    return null;
+  }
+
+  const statePath = response.data.state;
+  if (typeof statePath !== "string") {
+    return null;
+  }
+
+  return resolveAuthPathFromStatePath(statePath);
+};
+
+const parseAuthStore = (content: string): Record<string, unknown> | null => {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (parsed && typeof parsed === "object") {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const readCopilotEntry = (authPath: string): CopilotAuthEntry | null => {
+  if (!existsSync(authPath)) {
+    return null;
+  }
+
+  const content = readFileSync(authPath, "utf8");
+  const authStore = parseAuthStore(content);
+  if (!authStore) {
+    return null;
+  }
+
+  const candidate = authStore[COPILOT_AUTH_KEY];
+  if (!candidate || typeof candidate !== "object") {
+    return null;
+  }
+
+  return candidate as CopilotAuthEntry;
+};
+
+const buildCredentials = (entry: CopilotAuthEntry): CopilotCredentials | null => {
+  if (entry.type !== "oauth") {
+    return null;
+  }
+  if (typeof entry.refresh !== "string" || entry.refresh.length === EMPTY_LENGTH) {
+    return null;
+  }
+
+  return {
+    apiKey: entry.refresh,
+    baseURL: buildCopilotBaseURL(entry.enterpriseUrl),
+  };
+};
+
+const resolveCopilotCredentials = async (
+  client: PathClient,
+  directory: string,
+): Promise<CopilotCredentials | null> => {
+  const authPath = await resolveAuthPath(client, directory);
+  if (!authPath) {
+    return null;
+  }
+
+  const entry = readCopilotEntry(authPath);
+  if (!entry) {
+    return null;
+  }
+
+  return buildCredentials(entry);
+};
+
+export { resolveCopilotCredentials };

--- a/src/providers/copilot-auth.ts
+++ b/src/providers/copilot-auth.ts
@@ -74,7 +74,7 @@ const resolveAuthPathFromStatePath = (statePath: string | undefined): string | n
   }
 
   const dataMarker = `${sep}${SHARE_DIR}${sep}${OPENCODE_DIR}`;
-  const dataPath = statePath.replace(stateMarker, dataMarker);
+  const dataPath = `${statePath.slice(EMPTY_LENGTH, -stateMarker.length)}${dataMarker}`;
   return join(dataPath, AUTH_FILE_NAME);
 };
 

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1,0 +1,224 @@
+import {
+  COPILOT_INITIATOR,
+  COPILOT_INTENT,
+  COPILOT_USER_AGENT,
+  EMPTY_LENGTH,
+  MAX_RESPONSE_TOKENS,
+  SEARCH_SYSTEM_PROMPT,
+} from "../constants.js";
+import OpenAI, { APIError } from "openai";
+import { SearchArgs, SearchConfig, SearchHit, StructuredSearchResponse } from "../types.js";
+
+// ── Copilot response types (OpenAI-compatible Responses API) ───────────
+
+type ResponseFunctionWebSearch = OpenAI.Responses.ResponseFunctionWebSearch;
+type ResponseOutputItem = OpenAI.Responses.ResponseOutputItem;
+type ResponseOutputMessage = OpenAI.Responses.ResponseOutputMessage;
+type ResponseOutputText = OpenAI.Responses.ResponseOutputText;
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const WEB_SEARCH_INCLUDE: OpenAI.Responses.ResponseIncludable[] = [
+  "web_search_call.action.sources",
+];
+const WEB_SEARCH_TOOL: OpenAI.Responses.WebSearchTool = { type: "web_search" };
+
+// ── Text extraction ────────────────────────────────────────────────────
+
+const collectMessageTextParts = (items: ResponseOutputItem[]): string[] => {
+  const textParts: string[] = [];
+
+  for (const item of items) {
+    if (item.type !== "message") {
+      continue;
+    }
+    const message = item as ResponseOutputMessage;
+    for (const part of message.content) {
+      if (part.type !== "output_text") {
+        continue;
+      }
+      const textPart = part as ResponseOutputText;
+      const text = textPart.text.trim();
+      if (text.length > EMPTY_LENGTH) {
+        textParts.push(text);
+      }
+    }
+  }
+
+  return textParts;
+};
+
+const resolveOutputText = (outputText: string, items: ResponseOutputItem[]): string => {
+  const directText = outputText.trim();
+  if (directText.length > EMPTY_LENGTH) {
+    return directText;
+  }
+
+  const textParts = collectMessageTextParts(items);
+  if (textParts.length === EMPTY_LENGTH) {
+    return "";
+  }
+
+  return textParts.join("\n\n");
+};
+
+// ── Source extraction ──────────────────────────────────────────────────
+
+const pushUniqueHit = (seen: Set<string>, hits: SearchHit[], title: string, url: string): void => {
+  if (seen.has(url)) {
+    return;
+  }
+
+  seen.add(url);
+  hits.push({ title, url });
+};
+
+const extractAnnotationHits = (
+  annotations: ResponseOutputText["annotations"],
+  seen: Set<string>,
+  hits: SearchHit[],
+): void => {
+  for (const annotation of annotations) {
+    if (annotation.type !== "url_citation") {
+      continue;
+    }
+    pushUniqueHit(seen, hits, annotation.title, annotation.url);
+  }
+};
+
+const collectAnnotationHits = (
+  items: ResponseOutputItem[],
+  seen: Set<string>,
+  hits: SearchHit[],
+): void => {
+  for (const item of items) {
+    if (item.type !== "message") {
+      continue;
+    }
+    const message = item as ResponseOutputMessage;
+    for (const part of message.content) {
+      if (part.type !== "output_text") {
+        continue;
+      }
+      const outputText = part as ResponseOutputText;
+      if (outputText.annotations.length > EMPTY_LENGTH) {
+        extractAnnotationHits(outputText.annotations, seen, hits);
+      }
+    }
+  }
+};
+
+const collectWebSearchSourceHits = (
+  items: ResponseOutputItem[],
+  seen: Set<string>,
+  hits: SearchHit[],
+): void => {
+  for (const item of items) {
+    if (item.type !== "web_search_call") {
+      continue;
+    }
+
+    const call = item as ResponseFunctionWebSearch;
+    const { action } = call;
+    if (action.type !== "search") {
+      continue;
+    }
+
+    const { sources } = action;
+    if (!sources || sources.length === EMPTY_LENGTH) {
+      continue;
+    }
+
+    for (const source of sources) {
+      const title = source.url;
+      pushUniqueHit(seen, hits, title, source.url);
+    }
+  }
+};
+
+const collectSearchHits = (items: ResponseOutputItem[]): SearchHit[] => {
+  const seen = new Set<string>();
+  const hits: SearchHit[] = [];
+
+  collectAnnotationHits(items, seen, hits);
+  collectWebSearchSourceHits(items, seen, hits);
+
+  return hits;
+};
+
+// ── Structured response ────────────────────────────────────────────────
+
+const buildStructuredResponse = (
+  query: string,
+  outputText: string,
+  items: ResponseOutputItem[],
+): StructuredSearchResponse => {
+  const results: (SearchHit[] | string)[] = [];
+
+  const finalText = resolveOutputText(outputText, items);
+  if (finalText.length > EMPTY_LENGTH) {
+    results.push(finalText);
+  }
+
+  const hits = collectSearchHits(items);
+  if (hits.length > EMPTY_LENGTH) {
+    results.push(hits);
+  }
+
+  return { query, results };
+};
+
+// ── Error formatting ───────────────────────────────────────────────────
+
+const formatErrorMessage = (error: unknown): string => {
+  if (error instanceof APIError) {
+    return `GitHub Copilot API error: ${error.message} (status: ${error.status})`;
+  }
+  if (error instanceof Error) {
+    return `Error performing web search: ${error.message}`;
+  }
+  return `Error performing web search: ${String(error)}`;
+};
+
+// ── Client and execution ───────────────────────────────────────────────
+
+const createCopilotClient = (config: SearchConfig): OpenAI => {
+  const options: {
+    apiKey: string;
+    baseURL?: string;
+    defaultHeaders: Record<string, string>;
+  } = {
+    apiKey: config.apiKey,
+    defaultHeaders: {
+      "Openai-Intent": COPILOT_INTENT,
+      "User-Agent": COPILOT_USER_AGENT,
+      "x-initiator": COPILOT_INITIATOR,
+    },
+  };
+
+  if (config.baseURL) {
+    options.baseURL = config.baseURL;
+  }
+
+  return new OpenAI(options);
+};
+
+const executeSearch = async (config: SearchConfig, args: SearchArgs): Promise<string> => {
+  const client = createCopilotClient(config);
+
+  const response = await client.responses.create({
+    include: WEB_SEARCH_INCLUDE,
+    input: `Perform a web search for the query: ${args.query}`,
+    instructions: SEARCH_SYSTEM_PROMPT,
+    max_output_tokens: MAX_RESPONSE_TOKENS,
+    model: config.model,
+    tool_choice: "auto",
+    tools: [WEB_SEARCH_TOOL],
+  });
+
+  const structured = buildStructuredResponse(args.query, response.output_text, response.output);
+
+  return JSON.stringify(structured);
+};
+
+export { executeSearch, formatErrorMessage };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 // ── Shared Types ───────────────────────────────────────────────────────
 
 /**
- * Credentials needed to call a provider API (Anthropic or OpenAI).
- * Resolved from the provider's configuration in opencode.json.
+ * Credentials needed to call a provider API.
+ * Resolved from provider configuration and/or OpenCode auth state.
  */
 interface ProviderCredentials {
   apiKey: string;
@@ -12,7 +12,7 @@ interface ProviderCredentials {
 /**
  * Identifies which provider type a resolution belongs to.
  */
-type ProviderType = "anthropic" | "openai";
+type ProviderType = "anthropic" | "copilot" | "openai";
 
 /**
  * Fully resolved config for a single web search call:
@@ -43,6 +43,7 @@ interface ProviderResolution {
  */
 interface ProviderResolutionMap {
   anthropic?: ProviderResolution;
+  copilot?: ProviderResolution;
   openai?: ProviderResolution;
 }
 
@@ -70,7 +71,7 @@ interface SearchArgs {
 
 /**
  * A single search result hit with a title and URL.
- * Used by both Anthropic and OpenAI providers.
+ * Used by Anthropic, OpenAI, and Copilot providers.
  */
 interface SearchHit {
   title: string;


### PR DESCRIPTION
## Summary
- add GitHub Copilot as a first-class web-search provider alongside Anthropic and OpenAI, including provider detection, model resolution, dispatch, and provider-specific error handling
- implement Copilot auth resolution from OpenCode state via SDK path lookup and add a Copilot Responses API integration that returns structured text plus source links
- update README provider/model support docs, including tested vs untested model annotations and cleaner provider-native search mechanism references

## Validation
- bun run check