### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-websearch",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Web search plugin for OpenCode",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package version from 0.5.0 to 0.5.1 for the next release cut
- keeps release metadata aligned so follow-up tagging can trigger CI