### PR TITLE
fix: omit ChatGPT max output token parameter

### DIFF
--- a/src/providers/chatgpt/index.ts
+++ b/src/providers/chatgpt/index.ts
@@ -1,6 +1,5 @@
 import { formatUnhandledSearchError } from "../shared/errors.js";
 import {
-  MAX_RESPONSE_TOKENS,
   buildSearchInput,
   buildStructuredResponse,
   EMPTY_LENGTH,
@@ -105,7 +104,6 @@ const buildRequestBody = (config: SearchConfig, query: string): Record<string, u
     },
   ],
   instructions: SEARCH_SYSTEM_PROMPT,
-  max_output_tokens: MAX_RESPONSE_TOKENS,
   model: config.model,
   store: STORE_DISABLED,
   stream: STREAM_ENABLED,


### PR DESCRIPTION
## Summary
- Remove the unsupported `max_output_tokens` field from ChatGPT OAuth `/responses` requests.
- Keep OpenAI/Copilot provider behavior unchanged; this only affects the ChatGPT backend endpoint that rejects the parameter.

## Verification
- `bun run check`
- Confirmed locally in OpenCode that `web-search` no longer fails with `Unsupported parameter: max_output_tokens`.

Closes #17