### PR TITLE
feat: add Moonshot web search provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Asking OpenCode about the latest PostgreSQL version:
 | Provider         | What you need                                                            |
 | ---------------- | ------------------------------------------------------------------------ |
 | Anthropic        | An Anthropic provider/model in OpenCode with built-in web search support |
-| Moonshot (Kimi)  | A Moonshot API key configured in OpenCode                                 |
+| Moonshot (Kimi)  | A Moonshot API key configured in OpenCode                                |
 | OpenAI / ChatGPT | OpenAI configured in OpenCode (API key or ChatGPT connected)             |
 | GitHub Copilot   | GitHub Copilot connected in OpenCode                                     |
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Asking OpenCode about the latest PostgreSQL version:
 | Provider         | What you need                                                            |
 | ---------------- | ------------------------------------------------------------------------ |
 | Anthropic        | An Anthropic provider/model in OpenCode with built-in web search support |
+| Moonshot (Kimi)  | A Moonshot API key configured in OpenCode                                 |
 | OpenAI / ChatGPT | OpenAI configured in OpenCode (API key or ChatGPT connected)             |
 | GitHub Copilot   | GitHub Copilot connected in OpenCode                                     |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,8 +175,11 @@ const processProviderModel = (
   }
 
   const scan = state[providerType];
+  const candidate = extractCredentials(provider, providerType, model);
   if (!scan.credentials) {
-    scan.credentials = extractCredentials(provider, providerType, model);
+    scan.credentials = candidate;
+  } else if (!scan.credentials.baseURL && candidate?.baseURL) {
+    scan.credentials = { ...scan.credentials, baseURL: candidate.baseURL };
   }
 
   updateModelsFromWebsearchOption(scan, model);
@@ -286,7 +289,7 @@ const formatNoProviderError = (): string =>
 
 No supported provider credentials (API key or OAuth) were found.
 
-To fix this, add an Anthropic or OpenAI provider to your opencode.json:
+To fix this, add an Anthropic, OpenAI, or Moonshot provider to your opencode.json:
 
 {
   "provider": {
@@ -305,6 +308,18 @@ Or:
     "openai": {
       "options": {
         "apiKey": "{env:OPENAI_API_KEY}"
+      }
+    }
+  }
+}
+
+Or:
+
+{
+  "provider": {
+    "moonshot": {
+      "options": {
+        "apiKey": "{env:MOONSHOT_API_KEY}"
       }
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,10 @@ interface ProviderData {
 }
 
 interface ProviderModel {
-  api: { npm: string };
+  api: {
+    npm: string;
+    url?: string;
+  };
   id: string;
   options: Record<string, unknown>;
 }
@@ -35,6 +38,7 @@ interface ScanResult {
 interface ScanState {
   anthropic: ScanResult;
   copilot: ScanResult;
+  moonshot: ScanResult;
   openai: ScanResult;
 }
 
@@ -66,36 +70,69 @@ const extractApiKey = (options: Record<string, unknown>): string | undefined => 
   return options.apiKey;
 };
 
-const extractBaseURL = (
-  options: Record<string, unknown>,
-  providerType: ProviderType,
-): string | undefined => {
+const extractConfiguredBaseURL = (options: Record<string, unknown>): string | undefined => {
   if (typeof options.baseURL !== "string") {
     return undefined;
-  }
-
-  if (providerType === "anthropic") {
-    return normalizeBaseURL(options.baseURL);
   }
 
   return options.baseURL;
 };
 
+const normalizeProviderBaseURL = (providerType: ProviderType, baseURL: string): string => {
+  if (providerType === "anthropic") {
+    return normalizeBaseURL(baseURL);
+  }
+
+  return baseURL;
+};
+
+const extractModelBaseURL = (model: ProviderModel): string | undefined => {
+  if (typeof model.api.url !== "string") {
+    return undefined;
+  }
+
+  return model.api.url;
+};
+
+const resolveBaseURL = (
+  provider: ProviderData,
+  providerType: ProviderType,
+  model: ProviderModel,
+): string | undefined => {
+  const configuredBaseURL = extractConfiguredBaseURL(provider.options);
+  if (configuredBaseURL) {
+    return normalizeProviderBaseURL(providerType, configuredBaseURL);
+  }
+
+  const modelBaseURL = extractModelBaseURL(model);
+  if (!modelBaseURL) {
+    return undefined;
+  }
+
+  if (providerType === "anthropic") {
+    return normalizeBaseURL(modelBaseURL);
+  }
+
+  return modelBaseURL;
+};
+
 const extractCredentials = (
   provider: ProviderData,
   providerType: ProviderType,
+  model: ProviderModel,
 ): ProviderCredentials | null => {
   const apiKey = provider.key ?? extractApiKey(provider.options);
   if (!apiKey) {
     return null;
   }
 
-  return { apiKey, baseURL: extractBaseURL(provider.options, providerType) };
+  return { apiKey, baseURL: resolveBaseURL(provider, providerType, model) };
 };
 
 const createInitialScanState = (): ScanState => ({
   anthropic: { credentials: null },
   copilot: { credentials: null },
+  moonshot: { credentials: null },
   openai: { credentials: null },
 });
 
@@ -125,7 +162,10 @@ const processProviderModel = (
   model: ProviderModel,
   state: ScanState,
 ): void => {
-  const providerType = detectProviderTypeFromModel(model);
+  const providerType = detectProviderTypeFromModel({
+    model,
+    providerID: provider.id,
+  });
   if (!providerType) {
     return;
   }
@@ -136,7 +176,7 @@ const processProviderModel = (
 
   const scan = state[providerType];
   if (!scan.credentials) {
-    scan.credentials = extractCredentials(provider, providerType);
+    scan.credentials = extractCredentials(provider, providerType, model);
   }
 
   updateModelsFromWebsearchOption(scan, model);
@@ -187,6 +227,11 @@ const buildResolutionMap = (state: ScanState): ProviderResolutionMap => {
     result.openai = openai;
   }
 
+  const moonshot = buildResolution(state.moonshot, "moonshot");
+  if (moonshot) {
+    result.moonshot = moonshot;
+  }
+
   const copilot = buildResolution(state.copilot, "copilot");
   if (copilot) {
     result.copilot = copilot;
@@ -212,7 +257,7 @@ const resolveModelOverrides = (
 };
 
 /**
- * Scan providers for Anthropic, OpenAI, and GitHub Copilot credentials
+ * Scan providers for Anthropic, OpenAI, Moonshot, and GitHub Copilot credentials
  * and any websearch-tagged models.
  *
  * Resolution priority (per provider):
@@ -231,13 +276,13 @@ const resolveFromProviders = (providers: ProviderData[]): ProviderResolutionMap 
 // ── Error formatting ───────────────────────────────────────────────────
 
 const resolveGeneralModelHint = (): string =>
-  "claude-sonnet-4-6, claude-opus-4-6, gpt-5.4, gpt-5.4-mini";
+  "claude-sonnet-4-6, claude-opus-4-6, gpt-5.4, gpt-5.4-mini, kimi-k2.6";
 
 const resolveCopilotModelHint = (): string =>
   "gpt-5.3-codex, gpt-5.2-codex, gpt-5.2, gpt-5.1, gpt-5.4-mini";
 
 const formatNoProviderError = (): string =>
-  `Error: web-search requires an Anthropic, OpenAI (API key or ChatGPT OAuth), or GitHub Copilot provider.
+  `Error: web-search requires an Anthropic, OpenAI (API key or ChatGPT OAuth), Moonshot, or GitHub Copilot provider.
 
 No supported provider credentials (API key or OAuth) were found.
 
@@ -267,13 +312,13 @@ Or:
 
 Steps:
 1. Open your opencode.json (project root, .opencode/, or ~/.config/opencode/)
-2. Ensure you have an Anthropic/OpenAI provider configured with a valid API key, or active OpenAI ChatGPT OAuth/Copilot auth
+2. Ensure you have an Anthropic/OpenAI/Moonshot provider configured with a valid API key, or active OpenAI ChatGPT OAuth/Copilot auth
 3. Restart OpenCode to pick up the configuration change`;
 
 const formatUnsupportedProviderError = (activeModelID: string): string =>
   `Error: your current model (${activeModelID}) does not support web search.
 
-Web search requires an Anthropic, OpenAI, or GitHub Copilot web-search-capable model.
+Web search requires an Anthropic, OpenAI, Moonshot, or GitHub Copilot web-search-capable model.
 
 Known Copilot models that work with web search today include: ${resolveCopilotModelHint()}.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { resolveCopilotCredentials } from "./providers/copilot/auth.js";
 import { dispatchErrorMessage, dispatchSearch } from "./providers/index.js";
 import {
   RESOLUTION_PRIORITY,
-  detectProviderTypeFromNpm,
+  detectProviderTypeFromModel,
   detectProviderTypeFromProviderID,
 } from "./providers/registry.js";
 
@@ -29,11 +29,20 @@ const MIN_QUERY_LENGTH = 2;
 
 // ── Provider detection ─────────────────────────────────────────────────
 
-const detectUniformProviderType = (models: ProviderData["models"]): ProviderType | null => {
+const detectTypeFromProviderModel = (
+  provider: ProviderData,
+  model: ProviderData["models"][string],
+): ProviderType | null =>
+  detectProviderTypeFromModel({
+    model,
+    providerID: provider.id,
+  });
+
+const detectUniformProviderType = (provider: ProviderData): ProviderType | null => {
   let detectedType: ProviderType | null = null;
 
-  for (const model of Object.values(models)) {
-    const modelType = detectProviderTypeFromNpm(model.api.npm);
+  for (const model of Object.values(provider.models)) {
+    const modelType = detectTypeFromProviderModel(provider, model);
     if (!modelType) {
       continue;
     }
@@ -52,21 +61,21 @@ const detectUniformProviderType = (models: ProviderData["models"]): ProviderType
 };
 
 const detectProviderTypeFromProviderModels = (
-  models: ProviderData["models"],
+  provider: ProviderData,
   activeModelID: string,
 ): ProviderType | null => {
-  for (const model of Object.values(models)) {
+  for (const model of Object.values(provider.models)) {
     if (model.id !== activeModelID) {
       continue;
     }
 
-    const modelType = detectProviderTypeFromNpm(model.api.npm);
+    const modelType = detectTypeFromProviderModel(provider, model);
     if (modelType) {
       return modelType;
     }
   }
 
-  return detectUniformProviderType(models);
+  return detectUniformProviderType(provider);
 };
 
 const detectTypeFromActiveProvider = (
@@ -78,7 +87,7 @@ const detectTypeFromActiveProvider = (
       continue;
     }
 
-    const modelsType = detectProviderTypeFromProviderModels(provider.models, active.modelID);
+    const modelsType = detectProviderTypeFromProviderModels(provider, active.modelID);
     if (modelsType) {
       return modelsType;
     }
@@ -102,7 +111,7 @@ const detectTypeFromAnyModelMatch = (
         continue;
       }
 
-      const modelType = detectProviderTypeFromNpm(model.api.npm);
+      const modelType = detectTypeFromProviderModel(provider, model);
       if (modelType) {
         return modelType;
       }
@@ -319,6 +328,10 @@ const hasAnyProvider = (resolutions: ProviderResolutionMap): boolean => {
   }
 
   if (resolutions.openai) {
+    return true;
+  }
+
+  if (resolutions.moonshot) {
     return true;
   }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -12,6 +12,10 @@ import {
   formatErrorMessage as formatCopilotError,
 } from "./copilot/index.js";
 import {
+  executeSearch as executeMoonshotSearch,
+  formatErrorMessage as formatMoonshotError,
+} from "./moonshot/index.js";
+import {
   executeSearch as executeOpenAISearch,
   formatErrorMessage as formatOpenAIError,
 } from "./openai/index.js";
@@ -37,6 +41,10 @@ const PROVIDER_ADAPTERS: Record<ProviderType, ProviderAdapter> = {
   copilot: {
     executeSearch: executeCopilotSearch,
     formatErrorMessage: formatCopilotError,
+  },
+  moonshot: {
+    executeSearch: executeMoonshotSearch,
+    formatErrorMessage: formatMoonshotError,
   },
   openai: {
     executeSearch: executeOpenAISearch,

--- a/src/providers/moonshot/index.ts
+++ b/src/providers/moonshot/index.ts
@@ -45,6 +45,9 @@ interface MoonshotToolCallLike {
 
 // ── Constants ──────────────────────────────────────────────────────────
 
+const INITIAL_TURN = 0;
+const MAX_SEARCH_TURNS = 8;
+const TURN_INCREMENT = 1;
 const TOOL_CALL_FINISH_REASON = "tool_calls";
 const TOOL_ROLE = "tool";
 const USER_ROLE = "user";
@@ -187,40 +190,56 @@ const appendToolResultMessage = (
 
 // ── Client and execution ───────────────────────────────────────────────
 
-const executeSearchTurn = async (
+const buildEmptyResponse = (query: string): string =>
+  JSON.stringify(buildStructuredResponse(query, "", []));
+
+const buildFinalResponse = (query: string, message: OpenAI.ChatCompletionMessage): string => {
+  const hits = collectUniqueChatCompletionAnnotationHits(message);
+  const outputText = resolveChatCompletionOutputText(message);
+  const structured = buildStructuredResponse(query, outputText, hits);
+
+  return JSON.stringify(structured);
+};
+
+const buildMaxTurnsResponse = (query: string): string => {
+  const errorText = `Error: Moonshot web search exceeded the maximum of ${MAX_SEARCH_TURNS} tool-call turns without producing a final answer.`;
+
+  return JSON.stringify(buildStructuredResponse(query, errorText, []));
+};
+
+const runSearchLoop = async (
   client: OpenAI,
   model: string,
   messages: OpenAI.ChatCompletionMessageParam[],
   query: string,
 ): Promise<string> => {
-  const completion = await createCompletion(client, model, messages);
-  const [choice] = completion.choices;
-  if (!choice) {
-    return JSON.stringify(buildStructuredResponse(query, "", []));
+  for (let turn = INITIAL_TURN; turn < MAX_SEARCH_TURNS; turn += TURN_INCREMENT) {
+    // oxlint-disable-next-line no-await-in-loop -- each turn depends on the previous response
+    const completion = await createCompletion(client, model, messages);
+    const [choice] = completion.choices;
+    if (!choice) {
+      return buildEmptyResponse(query);
+    }
+
+    const toolCalls = extractFunctionToolCalls(choice.message);
+    if (choice.finish_reason !== TOOL_CALL_FINISH_REASON || toolCalls.length === EMPTY_LENGTH) {
+      return buildFinalResponse(query, choice.message);
+    }
+
+    appendAssistantToolCallMessage(messages, choice.message);
+    for (const toolCall of toolCalls) {
+      appendToolResultMessage(messages, toolCall);
+    }
   }
 
-  const toolCalls = extractFunctionToolCalls(choice.message);
-  if (choice.finish_reason !== TOOL_CALL_FINISH_REASON || toolCalls.length === EMPTY_LENGTH) {
-    const hits = collectUniqueChatCompletionAnnotationHits(choice.message);
-    const outputText = resolveChatCompletionOutputText(choice.message);
-    const structured = buildStructuredResponse(query, outputText, hits);
-
-    return JSON.stringify(structured);
-  }
-
-  appendAssistantToolCallMessage(messages, choice.message);
-  for (const toolCall of toolCalls) {
-    appendToolResultMessage(messages, toolCall);
-  }
-
-  return executeSearchTurn(client, model, messages, query);
+  return buildMaxTurnsResponse(query);
 };
 
 const executeSearch = async (config: SearchConfig, args: SearchArgs): Promise<string> => {
   const client = createOpenAICompatibleClient(config);
   const messages = buildMessages(args.query);
 
-  return executeSearchTurn(client, config.model, messages, args.query);
+  return runSearchLoop(client, config.model, messages, args.query);
 };
 
 export { executeSearch, formatErrorMessage };

--- a/src/providers/moonshot/index.ts
+++ b/src/providers/moonshot/index.ts
@@ -1,0 +1,226 @@
+import {
+  EMPTY_LENGTH,
+  SEARCH_SYSTEM_PROMPT,
+  buildSearchInput,
+  buildStructuredResponse,
+} from "../shared/search.js";
+import OpenAI, { APIError } from "openai";
+
+import { SearchArgs, SearchConfig } from "../../types.js";
+import { formatUnhandledSearchError } from "../shared/errors.js";
+import {
+  collectUniqueChatCompletionAnnotationHits,
+  createOpenAICompatibleClient,
+  resolveChatCompletionOutputText,
+} from "../shared/openai-compatible.js";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface MoonshotBuiltinFunctionTool {
+  function: { name: string };
+  type: "builtin_function";
+}
+
+interface MoonshotChatCompletionRequest {
+  messages: OpenAI.ChatCompletionMessageParam[];
+  model: string;
+  thinking: { type: "disabled" };
+  tool_choice: "auto";
+  tools: MoonshotBuiltinFunctionTool[];
+}
+
+interface MoonshotFunctionToolCall {
+  arguments: string;
+  id: string;
+  name: string;
+}
+
+interface MoonshotToolCallLike {
+  function?: {
+    arguments?: string;
+    name?: string;
+  };
+  id?: string;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const TOOL_CALL_FINISH_REASON = "tool_calls";
+const TOOL_ROLE = "tool";
+const USER_ROLE = "user";
+const WEB_SEARCH_FUNCTION_NAME = "$web_search";
+const WEB_SEARCH_TOOL: MoonshotBuiltinFunctionTool = {
+  function: { name: WEB_SEARCH_FUNCTION_NAME },
+  type: "builtin_function",
+};
+
+// ── Error formatting ───────────────────────────────────────────────────
+
+const formatErrorMessage = (error: unknown): string => {
+  if (error instanceof APIError) {
+    return `Moonshot API error: ${error.message} (status: ${error.status})`;
+  }
+
+  return formatUnhandledSearchError(error);
+};
+
+// ── Request helpers ────────────────────────────────────────────────────
+
+const buildMessages = (query: string): OpenAI.ChatCompletionMessageParam[] => [
+  {
+    content: SEARCH_SYSTEM_PROMPT,
+    role: "system",
+  },
+  {
+    content: buildSearchInput(query),
+    role: USER_ROLE,
+  },
+];
+
+const buildRequestBody = (
+  model: string,
+  messages: OpenAI.ChatCompletionMessageParam[],
+): MoonshotChatCompletionRequest => ({
+  messages,
+  model,
+  thinking: { type: "disabled" },
+  tool_choice: "auto",
+  tools: [WEB_SEARCH_TOOL],
+});
+
+const createCompletion = async (
+  client: OpenAI,
+  model: string,
+  messages: OpenAI.ChatCompletionMessageParam[],
+): Promise<OpenAI.ChatCompletion> =>
+  client.post<OpenAI.ChatCompletion>("/chat/completions", {
+    body: buildRequestBody(model, messages),
+  });
+
+const toMoonshotFunctionToolCall = (
+  toolCall: OpenAI.ChatCompletionMessageToolCall,
+): MoonshotFunctionToolCall | null => {
+  const candidate = toolCall as unknown as MoonshotToolCallLike;
+  if (typeof candidate.id !== "string") {
+    return null;
+  }
+
+  if (!candidate.function) {
+    return null;
+  }
+
+  const { arguments: callArguments, name } = candidate.function;
+  if (typeof callArguments !== "string") {
+    return null;
+  }
+
+  if (typeof name !== "string") {
+    return null;
+  }
+
+  return {
+    arguments: callArguments,
+    id: candidate.id,
+    name,
+  };
+};
+
+const extractFunctionToolCalls = (
+  message: OpenAI.ChatCompletionMessage,
+): MoonshotFunctionToolCall[] => {
+  if (!message.tool_calls) {
+    return [];
+  }
+
+  const toolCalls: MoonshotFunctionToolCall[] = [];
+  for (const toolCall of message.tool_calls) {
+    const parsed = toMoonshotFunctionToolCall(toolCall);
+    if (!parsed) {
+      continue;
+    }
+
+    toolCalls.push(parsed);
+  }
+
+  return toolCalls;
+};
+
+const appendAssistantToolCallMessage = (
+  messages: OpenAI.ChatCompletionMessageParam[],
+  message: OpenAI.ChatCompletionMessage,
+): void => {
+  messages.push({
+    content: message.content,
+    role: "assistant",
+    tool_calls: message.tool_calls,
+  });
+};
+
+const parseToolArguments = (toolCall: MoonshotFunctionToolCall): unknown => {
+  try {
+    return JSON.parse(toolCall.arguments) as unknown;
+  } catch {
+    return { error: "Invalid tool arguments JSON" };
+  }
+};
+
+const resolveToolResult = (toolCall: MoonshotFunctionToolCall): unknown => {
+  if (toolCall.name !== WEB_SEARCH_FUNCTION_NAME) {
+    return `Error: unable to find tool by name '${toolCall.name}'`;
+  }
+
+  return parseToolArguments(toolCall);
+};
+
+const appendToolResultMessage = (
+  messages: OpenAI.ChatCompletionMessageParam[],
+  toolCall: MoonshotFunctionToolCall,
+): void => {
+  const content = JSON.stringify(resolveToolResult(toolCall));
+  messages.push({
+    content,
+    name: toolCall.name,
+    role: TOOL_ROLE,
+    tool_call_id: toolCall.id,
+  } as unknown as OpenAI.ChatCompletionMessageParam);
+};
+
+// ── Client and execution ───────────────────────────────────────────────
+
+const executeSearchTurn = async (
+  client: OpenAI,
+  model: string,
+  messages: OpenAI.ChatCompletionMessageParam[],
+  query: string,
+): Promise<string> => {
+  const completion = await createCompletion(client, model, messages);
+  const [choice] = completion.choices;
+  if (!choice) {
+    return JSON.stringify(buildStructuredResponse(query, "", []));
+  }
+
+  const toolCalls = extractFunctionToolCalls(choice.message);
+  if (choice.finish_reason !== TOOL_CALL_FINISH_REASON || toolCalls.length === EMPTY_LENGTH) {
+    const hits = collectUniqueChatCompletionAnnotationHits(choice.message);
+    const outputText = resolveChatCompletionOutputText(choice.message);
+    const structured = buildStructuredResponse(query, outputText, hits);
+
+    return JSON.stringify(structured);
+  }
+
+  appendAssistantToolCallMessage(messages, choice.message);
+  for (const toolCall of toolCalls) {
+    appendToolResultMessage(messages, toolCall);
+  }
+
+  return executeSearchTurn(client, model, messages, query);
+};
+
+const executeSearch = async (config: SearchConfig, args: SearchArgs): Promise<string> => {
+  const client = createOpenAICompatibleClient(config);
+  const messages = buildMessages(args.query);
+
+  return executeSearchTurn(client, config.model, messages, args.query);
+};
+
+export { executeSearch, formatErrorMessage };

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -12,9 +12,23 @@ interface ProviderRule {
   type: ProviderType;
 }
 
+interface ProviderModelDetectionContext {
+  model: ProviderModelLike;
+  providerID: string;
+}
+
 // ── Constants ──────────────────────────────────────────────────────────
 
-const RESOLUTION_PRIORITY: ProviderType[] = ["anthropic", "chatgpt", "openai", "copilot"];
+const MOONSHOT_PROVIDER_ID = "moonshotai";
+const OPENAI_COMPATIBLE_PACKAGE = "@ai-sdk/openai-compatible";
+
+const RESOLUTION_PRIORITY: ProviderType[] = [
+  "anthropic",
+  "chatgpt",
+  "moonshot",
+  "openai",
+  "copilot",
+];
 
 const PROVIDER_RULES: ProviderRule[] = [
   {
@@ -36,6 +50,12 @@ const PROVIDER_RULES: ProviderRule[] = [
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
+const isMoonshotProviderID = (providerID: string): boolean => {
+  const normalizedProviderID = providerID.toLowerCase();
+
+  return normalizedProviderID === MOONSHOT_PROVIDER_ID;
+};
+
 const detectProviderTypeFromNpm = (npmPackage: string): ProviderType | null => {
   for (const rule of PROVIDER_RULES) {
     if (rule.npmPackage === npmPackage) {
@@ -47,6 +67,10 @@ const detectProviderTypeFromNpm = (npmPackage: string): ProviderType | null => {
 };
 
 const detectProviderTypeFromProviderID = (providerID: string): ProviderType | null => {
+  if (isMoonshotProviderID(providerID)) {
+    return "moonshot";
+  }
+
   const normalizedProviderID = providerID.toLowerCase();
 
   for (const rule of PROVIDER_RULES) {
@@ -60,8 +84,25 @@ const detectProviderTypeFromProviderID = (providerID: string): ProviderType | nu
   return null;
 };
 
-const detectProviderTypeFromModel = (model: ProviderModelLike): ProviderType | null =>
-  detectProviderTypeFromNpm(model.api.npm);
+const detectProviderTypeFromModel = (
+  context: ProviderModelDetectionContext,
+): ProviderType | null => {
+  const { model } = context;
+  const directType = detectProviderTypeFromNpm(model.api.npm);
+  if (directType) {
+    return directType;
+  }
+
+  if (model.api.npm !== OPENAI_COMPATIBLE_PACKAGE) {
+    return null;
+  }
+
+  if (isMoonshotProviderID(context.providerID)) {
+    return "moonshot";
+  }
+
+  return null;
+};
 
 export {
   detectProviderTypeFromModel,

--- a/src/providers/shared/openai-compatible.ts
+++ b/src/providers/shared/openai-compatible.ts
@@ -6,6 +6,7 @@ import { SearchConfig, SearchHit } from "../../types.js";
 // ── Types ──────────────────────────────────────────────────────────────
 
 type ResponseFunctionWebSearch = OpenAI.Responses.ResponseFunctionWebSearch;
+type ChatCompletionMessage = OpenAI.ChatCompletionMessage;
 type ResponseOutputItem = OpenAI.Responses.ResponseOutputItem;
 type ResponseOutputMessage = OpenAI.Responses.ResponseOutputMessage;
 type ResponseOutputText = OpenAI.Responses.ResponseOutputText;
@@ -74,6 +75,19 @@ const resolveOutputText = (outputText: string, items: ResponseOutputItem[]): str
   }
 
   return textParts.join("\n\n");
+};
+
+const resolveChatCompletionOutputText = (message: ChatCompletionMessage): string => {
+  if (typeof message.content !== "string") {
+    return "";
+  }
+
+  const content = message.content.trim();
+  if (content.length === EMPTY_LENGTH) {
+    return "";
+  }
+
+  return content;
 };
 
 // ── Search hit extraction ──────────────────────────────────────────────
@@ -161,9 +175,31 @@ const collectUniqueAnnotationAndSourceHits = (items: ResponseOutputItem[]): Sear
   return hits;
 };
 
+const collectUniqueChatCompletionAnnotationHits = (message: ChatCompletionMessage): SearchHit[] => {
+  const { annotations } = message;
+  if (!annotations || annotations.length === EMPTY_LENGTH) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  const hits: SearchHit[] = [];
+  for (const annotation of annotations) {
+    if (annotation.type !== "url_citation") {
+      continue;
+    }
+
+    const citation = annotation.url_citation;
+    pushUniqueHit(seen, hits, citation.title, citation.url);
+  }
+
+  return hits;
+};
+
 export {
   collectUniqueAnnotationAndSourceHits,
   collectUniqueAnnotationHits,
+  collectUniqueChatCompletionAnnotationHits,
   createOpenAICompatibleClient,
+  resolveChatCompletionOutputText,
   resolveOutputText,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ interface ProviderCredentials {
 /**
  * Identifies which provider type a resolution belongs to.
  */
-type ProviderType = "anthropic" | "chatgpt" | "copilot" | "openai";
+type ProviderType = "anthropic" | "chatgpt" | "copilot" | "moonshot" | "openai";
 
 /**
  * Fully resolved config for a single web search call:
@@ -47,6 +47,7 @@ interface ProviderResolutionMap {
   anthropic?: ProviderResolution;
   chatgpt?: ProviderResolution;
   copilot?: ProviderResolution;
+  moonshot?: ProviderResolution;
   openai?: ProviderResolution;
 }
 


### PR DESCRIPTION
## Summary
- add a Moonshot provider adapter that executes web search via Moonshot chat completions and builtin tool calls
- extend provider detection and resolution to recognize Moonshot and resolve base URLs from provider options or model API URL
- update shared OpenAI-compatible helpers and docs so Moonshot responses expose answer text and citations consistently

## Validation
- bun run check

Closes #16